### PR TITLE
More guava licensing

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -200,3 +200,20 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+  RIBs depends on the following libraries:
+
+  Copyright (C) 2017 The Guava Authors
+   
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/android/libraries/rib-uava/src/main/java/com/uber/rib/core/Preconditions.java
+++ b/android/libraries/rib-uava/src/main/java/com/uber/rib/core/Preconditions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 The Guava Authors
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
We need an entry into LICENSES for guava since we directly use some guava source code. Preconditions also needs a  modification copyright date since we have removed some of this code.