### PR TITLE
Remove Contributions section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ To integrate RIBs into your project using Carthage add the following to your `Ca
 github "uber/RIBs" ~> 0.9
 ```
 
-## Contributions
-
-We'd love for you to contribute to our open source projects. Before we can accept your contributions, we kindly ask you to sign our [Uber Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform).
-
-- If you **find a bug**, please open an issue or submit a fix via a pull request.
-- If you **have a feature request**, please open an issue or submit an implementation via a pull request
-- If you **want to contribute**, please submit a pull request.
-
 ## License
 
     Copyright (C) 2017 Uber Technologies


### PR DESCRIPTION
The CLA is handled by the CLA bot on PRs as needed, and contributions are handled and surfaced by GitHub via `CONTRIBUTING.md`.