### PR TITLE
Change the iOS RIB generation template to generate a view by default

### DIFF
--- a/ios/tooling/RIB.xctemplate/TemplateInfo.plist
+++ b/ios/tooling/RIB.xctemplate/TemplateInfo.plist
@@ -51,7 +51,7 @@
 			<key>Type</key>
 			<string>checkbox</string>
 			<key>Default</key>
-			<string>false</string>
+			<string>true</string>
 			<key>NotPersisted</key>
 			<string>true</string>
 		</dict>


### PR DESCRIPTION
This is because of two reasons:
1. A majority RIBs that do have views (both in practice, as well as in the examples)
2. To have the code generation defaults be in line with the Android generator (and the main use case). Confirmed with @sbarow, who has contributed much to the original code generator.