### PR TITLE
Add file header to iOS template files

### DIFF
--- a/ios/tooling/RIB Unit Tests.xctemplate/Default/___FILEBASENAME___InteractorTests.swift
+++ b/ios/tooling/RIB Unit Tests.xctemplate/Default/___FILEBASENAME___InteractorTests.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 @testable import ___PROJECTNAME___
 import XCTest
 

--- a/ios/tooling/RIB Unit Tests.xctemplate/Default/___FILEBASENAME___RouterTests.swift
+++ b/ios/tooling/RIB Unit Tests.xctemplate/Default/___FILEBASENAME___RouterTests.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 @testable import ___PROJECTNAME___
 import XCTest
 

--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Builder.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Builder.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 
 protocol ___VARIABLE_productName___Dependency: Dependency {

--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 import RxSwift
 

--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 
 protocol ___VARIABLE_productName___Interactable: Interactable {

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 
 protocol ___VARIABLE_productName___Dependency: Dependency {

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 import RxSwift
 

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 
 protocol ___VARIABLE_productName___Interactable: Interactable {

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
@@ -1,3 +1,5 @@
+//___FILEHEADER___
+
 import RIBs
 import RxSwift
 import UIKit


### PR DESCRIPTION
Adds `___FILEHEADER___` to the RIB template files so they match the default Xcode template behavior, e.g.:
```
//
//  File.swift
//  ProjectName
//
//  Created by Alex Perez on 11/8/17.
//  Copyright © 2017 Alex Perez. All rights reserved.
//
```