### PR TITLE
Added RIB's template option to create a corresponding XIB file

### DIFF
--- a/ios/tooling/RIB.xctemplate/TemplateInfo.plist
+++ b/ios/tooling/RIB.xctemplate/TemplateInfo.plist
@@ -55,6 +55,27 @@
 			<key>NotPersisted</key>
 			<string>true</string>
 		</dict>
+		<dict>
+			<key>Identifier</key>
+			<string>withXIB</string>
+			<key>Required</key>
+			<string>true</string>
+			<key>Name</key>
+			<string>Adds XIB file</string>
+			<key>Description</key>
+			<string>Whether this RIB contains a corresponding view with XIB</string>
+			<key>Type</key>
+			<string>checkbox</string>
+			<key>Default</key>
+			<string>false</string>
+			<key>NotPersisted</key>
+			<string>true</string>
+			<key>RequiredOptions</key>
+			<dict>
+				<key>ownsView</key>
+				<string>true</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/ios/tooling/RIB.xctemplate/ownsViewwithXIB/___FILEBASENAME___ViewController.xib
+++ b/ios/tooling/RIB.xctemplate/ownsViewwithXIB/___FILEBASENAME___ViewController.xib
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="___VARIABLE_productName___ViewController">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="jYO-eb-xeE"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/ios/tooling/install-xcode-template.sh
+++ b/ios/tooling/install-xcode-template.sh
@@ -12,6 +12,8 @@ xcodeTemplate () {
   fi
   mkdir -p "$XCODE_TEMPLATE_DIR"
   cp -R *.xctemplate "$XCODE_TEMPLATE_DIR"
+  
+  cp -R RIB.xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/RIB.xctemplate/ownsViewwithXIB/"
 }
 
 xcodeTemplate


### PR DESCRIPTION
Changes:

1. Added another checkbox in a new RIB template
2. This checkbox is active only in case when "owns the corresponding view" is checked
3. Installation script copies "default" RIB files into template with XIB folder