### PR TITLE
Added RIB's template option to create a corresponding Storyboard file

### DIFF
--- a/ios/tooling/RIB.xctemplate/TemplateInfo.plist
+++ b/ios/tooling/RIB.xctemplate/TemplateInfo.plist
@@ -74,6 +74,31 @@
 			<dict>
 				<key>ownsView</key>
 				<string>true</string>
+				<key>withStoryboard</key>
+				<string>false</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Identifier</key>
+			<string>withStoryboard</string>
+			<key>Required</key>
+			<string>true</string>
+			<key>Name</key>
+			<string>Adds Storyboard file</string>
+			<key>Description</key>
+			<string>Whether this RIB contains a corresponding view with Storyboard</string>
+			<key>Type</key>
+			<string>checkbox</string>
+			<key>Default</key>
+			<string>false</string>
+			<key>NotPersisted</key>
+			<string>true</string>
+			<key>RequiredOptions</key>
+			<dict>
+				<key>ownsView</key>
+				<string>true</string>
+				<key>withXIB</key>
+				<string>false</string>
 			</dict>
 		</dict>
 	</array>

--- a/ios/tooling/RIB.xctemplate/ownsViewwithStoryboard/___FILEBASENAME___ViewController.storyboard
+++ b/ios/tooling/RIB.xctemplate/ownsViewwithStoryboard/___FILEBASENAME___ViewController.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vKn-9P-Ny8">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--product Name View Controller-->
+        <scene sceneID="GzV-lN-fg7">
+            <objects>
+                <viewController id="vKn-9P-Ny8" customClass="___VARIABLE_productName___ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BNZ-bO-rhc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <viewLayoutGuide key="safeArea" id="HgA-Aw-ocO"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="k0X-am-vwV" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="244" y="205"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios/tooling/install-xcode-template.sh
+++ b/ios/tooling/install-xcode-template.sh
@@ -14,6 +14,7 @@ xcodeTemplate () {
   cp -R *.xctemplate "$XCODE_TEMPLATE_DIR"
   
   cp -R RIB.xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/RIB.xctemplate/ownsViewwithXIB/"
+  cp -R RIB.xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/RIB.xctemplate/ownsViewwithStoryboard/"
 }
 
 xcodeTemplate


### PR DESCRIPTION
inspired by this idea: https://github.com/uber/RIBs/pull/171

### Changes

- 1. Added another checkbox to add storyboard
- 2. This checkbox is active only in case when "owns the corresponding view" is checked, and "with XIB' checkbox is inactive
- 3. Installation script copies "default" RIB files into template with Storyboard folder