### PR TITLE
Fix xcode template installation script file copying

### DIFF
--- a/ios/tooling/install-xcode-template.sh
+++ b/ios/tooling/install-xcode-template.sh
@@ -2,6 +2,7 @@
 
 # Configuration
 XCODE_TEMPLATE_DIR=$HOME'/Library/Developer/Xcode/Templates/File Templates/RIBs'
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Copy RIBs file templates into the local RIBs template directory
 xcodeTemplate () {
@@ -11,9 +12,10 @@ xcodeTemplate () {
     rm -R "$XCODE_TEMPLATE_DIR"
   fi
   mkdir -p "$XCODE_TEMPLATE_DIR"
-  cp -R *.xctemplate "$XCODE_TEMPLATE_DIR"
+
+  cp -R $SCRIPT_DIR/*.xctemplate "$XCODE_TEMPLATE_DIR"
   
-  cp -R RIB.xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/RIB.xctemplate/ownsViewwithXIB/"
+  cp -R $SCRIPT_DIR/RIB.xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/RIB.xctemplate/ownsViewwithXIB/"
 }
 
 xcodeTemplate


### PR DESCRIPTION
Tested with the following commands:
`./install-xcode-template.sh`
`tooling/install-xcode-template.sh`
both commands successfully copied the template files to `Xcode/Templates/File Templates/RIBs`.