### PR TITLE
Fix view-less RIB template

### DIFF
--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Builder.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Builder.swift
@@ -35,6 +35,6 @@ final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_productName__
         let component = ___VARIABLE_productName___Component(dependency: dependency)
         let interactor = ___VARIABLE_productName___Interactor()
         interactor.listener = listener
-        return ___VARIABLE_productName___Router(interactor: interactor)
+        return ___VARIABLE_productName___Router(interactor: interactor, viewController: component.___VARIABLE_productName___ViewController)
     }
 }

--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -16,8 +16,9 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactable>, ___VARIABLE_productName___Routing {
 
     // TODO: Constructor inject child builder protocols to allow building children.
-    override init(interactor: ___VARIABLE_productName___Interactable) {
-        super.init(interactor: interactor)
+    override init(interactor: ___VARIABLE_productName___Interactable, viewController: ___VARIABLE_productName___ViewControllable) {
+        self.viewController = viewController
+        super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
 
@@ -25,4 +26,8 @@ final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___I
         // TODO: Since this router does not own its view, it needs to cleanup the views
         // it may have added to the view hierarchy, when its interactor is deactivated.
     }
+
+    // MARK: - Private
+
+    private let viewController: ___VARIABLE_productName___ViewControllable
 }


### PR DESCRIPTION
View-less RIBs should not inherit from `ViewableRouter` or `PresentableInteractor`.