### PR TITLE
Fix tutorials view-less RIB inheritance

### DIFF
--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -35,7 +35,6 @@ protocol LoggedInListener: class {
 final class LoggedInInteractor: Interactor, LoggedInInteractable {
 
     weak var router: LoggedInRouting?
-
     weak var listener: LoggedInListener?
 
     // TODO: Add additional dependencies to constructor. Do not perform any logic

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -26,15 +26,16 @@ protocol LoggedInViewControllable: ViewControllable {
     func dismiss(viewController: ViewControllable)
 }
 
-final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
+final class LoggedInRouter: Router<LoggedInInteractable>, LoggedInRouting {
 
     init(interactor: LoggedInInteractable,
          viewController: LoggedInViewControllable,
          offGameBuilder: OffGameBuildable,
          ticTacToeBuilder: TicTacToeBuildable) {
+        self.viewController = viewController
         self.offGameBuilder = offGameBuilder
         self.ticTacToeBuilder = ticTacToeBuilder
-        super.init(interactor: interactor, viewController: viewController)
+        super.init(interactor: interactor)
         interactor.router = self
     }
 
@@ -67,6 +68,7 @@ final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewCon
 
     // MARK: - Private
 
+    private let viewController: LoggedInViewControllable
     private let offGameBuilder: OffGameBuildable
     private let ticTacToeBuilder: TicTacToeBuildable
 

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -35,7 +35,6 @@ protocol LoggedInListener: class {
 final class LoggedInInteractor: Interactor, LoggedInInteractable {
 
     weak var router: LoggedInRouting?
-
     weak var listener: LoggedInListener?
 
     // TODO: Add additional dependencies to constructor. Do not perform any logic

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -26,15 +26,16 @@ protocol LoggedInViewControllable: ViewControllable {
     func dismiss(viewController: ViewControllable)
 }
 
-final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
+final class LoggedInRouter: Router<LoggedInInteractable>, LoggedInRouting {
 
     init(interactor: LoggedInInteractable,
          viewController: LoggedInViewControllable,
          offGameBuilder: OffGameBuildable,
          ticTacToeBuilder: TicTacToeBuildable) {
+        self.viewController = viewController
         self.offGameBuilder = offGameBuilder
         self.ticTacToeBuilder = ticTacToeBuilder
-        super.init(interactor: interactor, viewController: viewController)
+        super.init(interactor: interactor)
         interactor.router = self
     }
 
@@ -67,6 +68,7 @@ final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewCon
 
     // MARK: - Private
 
+    private let viewController: LoggedInViewControllable
     private let offGameBuilder: OffGameBuildable
     private let ticTacToeBuilder: TicTacToeBuildable
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -30,7 +30,6 @@ protocol LoggedInListener: class {
 final class LoggedInInteractor: Interactor, LoggedInInteractable, LoggedInActionableItem {
 
     weak var router: LoggedInRouting?
-
     weak var listener: LoggedInListener?
 
     // TODO: Add additional dependencies to constructor. Do not perform any logic

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -25,13 +25,14 @@ protocol LoggedInViewControllable: ViewControllable {
     func replaceModal(viewController: ViewControllable?)
 }
 
-final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
+final class LoggedInRouter: Router<LoggedInInteractable>, LoggedInRouting {
 
     init(interactor: LoggedInInteractable,
          viewController: LoggedInViewControllable,
          offGameBuilder: OffGameBuildable) {
+        self.viewController = viewController
         self.offGameBuilder = offGameBuilder
-        super.init(interactor: interactor, viewController: viewController)
+        super.init(interactor: interactor)
         interactor.router = self
     }
 
@@ -59,6 +60,7 @@ final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewCon
 
     // MARK: - Private
 
+    private let viewController: LoggedInViewControllable
     private let offGameBuilder: OffGameBuildable
 
     private var currentChild: ViewableRouting?

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -30,7 +30,6 @@ protocol LoggedInListener: class {
 final class LoggedInInteractor: Interactor, LoggedInInteractable {
 
     weak var router: LoggedInRouting?
-
     weak var listener: LoggedInListener?
 
     // TODO: Add additional dependencies to constructor. Do not perform any logic

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -25,13 +25,14 @@ protocol LoggedInViewControllable: ViewControllable {
     func replaceModal(viewController: ViewControllable?)
 }
 
-final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
+final class LoggedInRouter: Router<LoggedInInteractable>, LoggedInRouting {
 
     init(interactor: LoggedInInteractable,
          viewController: LoggedInViewControllable,
          offGameBuilder: OffGameBuildable) {
+        self.viewController = viewController
         self.offGameBuilder = offGameBuilder
-        super.init(interactor: interactor, viewController: viewController)
+        super.init(interactor: interactor)
         interactor.router = self
     }
 
@@ -59,6 +60,7 @@ final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewCon
 
     // MARK: - Private
 
+    private let viewController: LoggedInViewControllable
     private let offGameBuilder: OffGameBuildable
 
     private var currentChild: ViewableRouting?


### PR DESCRIPTION
View-less RIBs should not inherit from `ViewableRouter`. It'll cause false positive leak detection.