### PR TITLE
Fix viewless RIB template

### DIFF
--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -16,9 +16,9 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactable>, ___VARIABLE_productName___Routing {
 
     // TODO: Constructor inject child builder protocols to allow building children.
-    override init(interactor: ___VARIABLE_productName___Interactable, viewController: ___VARIABLE_productName___ViewControllable) {
+    init(interactor: ___VARIABLE_productName___Interactable, viewController: ___VARIABLE_productName___ViewControllable) {
         self.viewController = viewController
-        super.init(interactor: interactor, viewController: viewController)
+        super.init(interactor: interactor)
         interactor.router = self
     }
 


### PR DESCRIPTION
The `Router` initializer does not `override` a parent initializer;.

Fixes #192