### PR TITLE
Remove uiviewController property from template

### DIFF
--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
@@ -12,8 +12,5 @@ protocol ___VARIABLE_productName___PresentableListener: class {
 
 final class ___VARIABLE_productName___ViewController: UIViewController, ___VARIABLE_productName___Presentable, ___VARIABLE_productName___ViewControllable {
 
-    /// The UIKit view representation of this view.
-    public final var uiviewController: UIViewController { return self }
-
     weak var listener: ___VARIABLE_productName___PresentableListener?
 }


### PR DESCRIPTION
The `uiviewController` property in the ownsView ViewController template is redundant. The extension in [ViewControllable.swift](https://github.com/uber/RIBs/blob/master/ios/RIBs/Classes/ViewControllable.swift) already defines the same default implementation. 