### PR TITLE
Enable NullAway on memory leaks demo

### DIFF
--- a/android/demos/memory-leaks/build.gradle
+++ b/android/demos/memory-leaks/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     annotationProcessor deps.apt.daggerCompiler
     annotationProcessor project(":libraries:rib-compiler-app")
     annotationProcessor project(":libraries:rib-compiler-test")
+    annotationProcessor deps.apt.nullAway
     compile project(":libraries:rib-android")
     compile deps.external.dagger
     compile deps.external.rxbinding
@@ -79,9 +80,11 @@ tasks.withType(JavaCompile) {
             "-Xep:InvalidPatternSyntax:OFF",
             "-Xep:OperatorPrecedence:OFF",
             "-Xep:DefaultCharset:OFF"]
-    // Dagger doesn't pass the NullAway checks. So we need to set NullAway to null
-    // use the following flag to disable nullaway on generated code.
+    // NullAway configuration
     options.compilerArgs += [
-            "-XepDisableWarningsInGeneratedCode"
-    ]
+            "-Xep:NullAway:ERROR",
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+            // Dagger doesn't pass the NullAway checks. So we
+            // use the following flag to disable Error Prone on generated code.
+            "-XepExcludedPaths:.*/build/generated/.*"]
 }

--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -21,14 +21,14 @@ def versions = [
     robolectric: "3.4.2",
     intellij: "2017.2",
     rave: "2.0.0",
-    errorProne: '2.0.19',
+    errorProne: '2.2.0',
 ]
 
 def apt = [
     androidApi: "com.google.android:android:2.2.1",
     autoCommon: "com.google.auto:auto-common:0.8",
     autoService: "com.google.auto.service:auto-service:1.0-rc3",
-    nullAway: 'com.uber.nullaway:nullaway:0.1.4',
+    nullAway: 'com.uber.nullaway:nullaway:0.3.2',
     daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
     javapoet: "com.squareup:javapoet:1.9.0",
     javax: "javax.annotation:jsr250-api:1.0",

--- a/android/tooling/autodispose-error-prone-checker/build.gradle
+++ b/android/tooling/autodispose-error-prone-checker/build.gradle
@@ -17,6 +17,10 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'net.ltgt.errorprone'
 
+// we use this config to get the path of the JDK 9 javac jar, to
+// stick it in the bootclasspath when running tests
+configurations.maybeCreate("epJavac")
+
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -30,8 +34,14 @@ dependencies {
     compileOnly deps.apt.autoService
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
+    epJavac deps.build.errorProneCore
+
     testCompile deps.test.junit
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+}
+
+test {
+  jvmArgs "-Xbootclasspath/p:${configurations.epJavac.asPath}"
 }

--- a/android/tutorials/tutorial1/build.gradle
+++ b/android/tutorials/tutorial1/build.gradle
@@ -17,9 +17,11 @@
 buildscript {
     dependencies {
         classpath deps.build.gradlePlugins.android
+        classpath deps.build.gradlePlugins.errorprone
     }
 }
 
+apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'com.android.application'
 
 android {
@@ -44,9 +46,21 @@ android {
 dependencies {
     annotationProcessor deps.apt.daggerCompiler
     annotationProcessor project(":libraries:rib-compiler-test")
+    annotationProcessor deps.apt.nullAway
     compile project(":libraries:rib-android")
     compile deps.external.dagger
     compile deps.external.rxbinding
     provided deps.apt.javax
     testCompile project(":libraries:rib-test-utils")
+    errorprone deps.build.errorProne
+}
+
+tasks.withType(JavaCompile) {
+    // NullAway configuration
+    options.compilerArgs += [
+            "-Xep:NullAway:ERROR",
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+            // Dagger doesn't pass the NullAway checks. So we
+            // use the following flag to disable Error Prone on generated code.
+            "-XepExcludedPaths:.*/build/generated/.*"]
 }

--- a/android/tutorials/tutorial1/build.gradle
+++ b/android/tutorials/tutorial1/build.gradle
@@ -57,10 +57,12 @@ dependencies {
 
 tasks.withType(JavaCompile) {
     // NullAway configuration
-    options.compilerArgs += [
-            "-Xep:NullAway:ERROR",
-            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-            // Dagger doesn't pass the NullAway checks. So we
-            // use the following flag to disable Error Prone on generated code.
-            "-XepExcludedPaths:.*/build/generated/.*"]
+    if (!name.toLowerCase().contains("test")) {
+        options.compilerArgs += [
+                "-Xep:NullAway:ERROR",
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                // Dagger doesn't pass the NullAway checks. So we
+                // use the following flag to disable Error Prone on generated code.
+                "-XepExcludedPaths:.*/build/generated/.*"]
+    }
 }

--- a/android/tutorials/tutorial2/build.gradle
+++ b/android/tutorials/tutorial2/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
+    options.compilerArgs += [
+            "-Xep:CheckReturnValue:OFF"]
     // NullAway configuration
     options.compilerArgs += [
             "-Xep:NullAway:ERROR",

--- a/android/tutorials/tutorial2/build.gradle
+++ b/android/tutorials/tutorial2/build.gradle
@@ -17,9 +17,11 @@
 buildscript {
     dependencies {
         classpath deps.build.gradlePlugins.android
+        classpath deps.build.gradlePlugins.errorprone
     }
 }
 
+apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'com.android.application'
 
 android {
@@ -44,6 +46,7 @@ android {
 dependencies {
     annotationProcessor deps.apt.daggerCompiler
     annotationProcessor project(":libraries:rib-compiler-test")
+    annotationProcessor deps.apt.nullAway
     compile project(":libraries:rib-android")
     compile 'com.android.support:percent:25.0.1'
     compile deps.external.dagger
@@ -51,4 +54,15 @@ dependencies {
     provided deps.apt.androidApi
     provided deps.apt.javax
     testCompile project(":libraries:rib-test-utils")
+    errorprone deps.build.errorProne
+}
+
+tasks.withType(JavaCompile) {
+    // NullAway configuration
+    options.compilerArgs += [
+            "-Xep:NullAway:ERROR",
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+            // Dagger doesn't pass the NullAway checks. So we
+            // use the following flag to disable Error Prone on generated code.
+            "-XepExcludedPaths:.*/build/generated/.*"]
 }

--- a/android/tutorials/tutorial2/build.gradle
+++ b/android/tutorials/tutorial2/build.gradle
@@ -58,13 +58,14 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs += [
-            "-Xep:CheckReturnValue:OFF"]
+    options.compilerArgs += ["-Xep:CheckReturnValue:OFF"]
     // NullAway configuration
-    options.compilerArgs += [
-            "-Xep:NullAway:ERROR",
-            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-            // Dagger doesn't pass the NullAway checks. So we
-            // use the following flag to disable Error Prone on generated code.
-            "-XepExcludedPaths:.*/build/generated/.*"]
+    if (!name.toLowerCase().contains("test")) {
+        options.compilerArgs += [
+                "-Xep:NullAway:ERROR",
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                // Dagger doesn't pass the NullAway checks. So we
+                // use the following flag to disable Error Prone on generated code.
+                "-XepExcludedPaths:.*/build/generated/.*"]
+    }
 }


### PR DESCRIPTION
Bump Error Prone and NullAway versions, and leverage the `-XepExcludedPaths` option to prevent checking of Dagger-generated code.
