### PR TITLE
Fix forked Workflow invoking didComplete multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ### Version 0.1.0
 
 * Initial release
+
+### Version 0.9.2
+
+* Fix forked Workflow invoking didComplete multiple times

--- a/RIBs.podspec
+++ b/RIBs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RIBs'
-  s.version          = '0.9.1'
+  s.version          = '0.9.2'
   s.summary          = 'Uber\'s cross-platform mobile architecture.'
   s.description      = <<-DESC
 RIBs is the cross-platform architecture behind many mobile apps at Uber. This architecture framework is designed for mobile apps with a large number of engineers and nested states.


### PR DESCRIPTION
Because didComplete is added at the end of the Workflow Rx side-effect, if a Workflow is forked, multiple Rx chains with the side-effect are created and subscribed to. This means the didComplete is invoked duplicately.

Fixes #211

<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
