### PR TITLE
Remove weak property keyword from protocols

### DIFF
--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -3,8 +3,8 @@
 import RIBs
 
 protocol ___VARIABLE_productName___Interactable: Interactable {
-    weak var router: ___VARIABLE_productName___Routing? { get set }
-    weak var listener: ___VARIABLE_productName___Listener? { get set }
+    var router: ___VARIABLE_productName___Routing? { get set }
+    var listener: ___VARIABLE_productName___Listener? { get set }
 }
 
 protocol ___VARIABLE_productName___ViewControllable: ViewControllable {

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -8,7 +8,7 @@ protocol ___VARIABLE_productName___Routing: ViewableRouting {
 }
 
 protocol ___VARIABLE_productName___Presentable: Presentable {
-    weak var listener: ___VARIABLE_productName___PresentableListener? { get set }
+    var listener: ___VARIABLE_productName___PresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -3,8 +3,8 @@
 import RIBs
 
 protocol ___VARIABLE_productName___Interactable: Interactable {
-    weak var router: ___VARIABLE_productName___Routing? { get set }
-    weak var listener: ___VARIABLE_productName___Listener? { get set }
+    var router: ___VARIABLE_productName___Routing? { get set }
+    var listener: ___VARIABLE_productName___Listener? { get set }
 }
 
 protocol ___VARIABLE_productName___ViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial1/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial1/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial1/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial1/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -22,7 +22,7 @@ protocol LoggedOutRouting: ViewableRouting {
 }
 
 protocol LoggedOutPresentable: Presentable {
-    weak var listener: LoggedOutPresentableListener? { get set }
+    var listener: LoggedOutPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutRouter.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedOutInteractable: Interactable {
-    weak var router: LoggedOutRouting? { get set }
-    weak var listener: LoggedOutListener? { get set }
+    var router: LoggedOutRouting? { get set }
+    var listener: LoggedOutListener? { get set }
 }
 
 protocol LoggedOutViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial2/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -22,7 +22,7 @@ protocol TicTacToeRouting: ViewableRouting {
 }
 
 protocol TicTacToePresentable: Presentable {
-    weak var listener: TicTacToePresentableListener? { get set }
+    var listener: TicTacToePresentableListener? { get set }
     func setCell(atRow row: Int, col: Int, withPlayerType playerType: PlayerType)
     func announce(winner: PlayerType)
 }

--- a/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeRouter.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol TicTacToeInteractable: Interactable {
-    weak var router: TicTacToeRouting? { get set }
-    weak var listener: TicTacToeListener? { get set }
+    var router: TicTacToeRouting? { get set }
+    var listener: TicTacToeListener? { get set }
 }
 
 protocol TicTacToeViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedInInteractable: Interactable, OffGameListener, TicTacToeListener {
-    weak var router: LoggedInRouting? { get set }
-    weak var listener: LoggedInListener? { get set }
+    var router: LoggedInRouting? { get set }
+    var listener: LoggedInListener? { get set }
 }
 
 protocol LoggedInViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -22,7 +22,7 @@ protocol LoggedOutRouting: ViewableRouting {
 }
 
 protocol LoggedOutPresentable: Presentable {
-    weak var listener: LoggedOutPresentableListener? { get set }
+    var listener: LoggedOutPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedOutInteractable: Interactable {
-    weak var router: LoggedOutRouting? { get set }
-    weak var listener: LoggedOutListener? { get set }
+    var router: LoggedOutRouting? { get set }
+    var listener: LoggedOutListener? { get set }
 }
 
 protocol LoggedOutViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameInteractor.swift
@@ -22,7 +22,7 @@ protocol OffGameRouting: ViewableRouting {
 }
 
 protocol OffGamePresentable: Presentable {
-    weak var listener: OffGamePresentableListener? { get set }
+    var listener: OffGamePresentableListener? { get set }
     func set(score: Score)
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol OffGameInteractable: Interactable {
-    weak var router: OffGameRouting? { get set }
-    weak var listener: OffGameListener? { get set }
+    var router: OffGameRouting? { get set }
+    var listener: OffGameListener? { get set }
 }
 
 protocol OffGameViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener, LoggedInListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -22,7 +22,7 @@ protocol TicTacToeRouting: ViewableRouting {
 }
 
 protocol TicTacToePresentable: Presentable {
-    weak var listener: TicTacToePresentableListener? { get set }
+    var listener: TicTacToePresentableListener? { get set }
     func setCell(atRow row: Int, col: Int, withPlayerType playerType: PlayerType)
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }

--- a/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeRouter.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol TicTacToeInteractable: Interactable {
-    weak var router: TicTacToeRouting? { get set }
-    weak var listener: TicTacToeListener? { get set }
+    var router: TicTacToeRouting? { get set }
+    var listener: TicTacToeListener? { get set }
 }
 
 protocol TicTacToeViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedInInteractable: Interactable, OffGameListener, TicTacToeListener {
-    weak var router: LoggedInRouting? { get set }
-    weak var listener: LoggedInListener? { get set }
+    var router: LoggedInRouting? { get set }
+    var listener: LoggedInListener? { get set }
 }
 
 protocol LoggedInViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -22,7 +22,7 @@ protocol LoggedOutRouting: ViewableRouting {
 }
 
 protocol LoggedOutPresentable: Presentable {
-    weak var listener: LoggedOutPresentableListener? { get set }
+    var listener: LoggedOutPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedOutInteractable: Interactable {
-    weak var router: LoggedOutRouting? { get set }
-    weak var listener: LoggedOutListener? { get set }
+    var router: LoggedOutRouting? { get set }
+    var listener: LoggedOutListener? { get set }
 }
 
 protocol LoggedOutViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameInteractor.swift
@@ -22,7 +22,7 @@ protocol OffGameRouting: ViewableRouting {
 }
 
 protocol OffGamePresentable: Presentable {
-    weak var listener: OffGamePresentableListener? { get set }
+    var listener: OffGamePresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol OffGameInteractable: Interactable {
-    weak var router: OffGameRouting? { get set }
-    weak var listener: OffGameListener? { get set }
+    var router: OffGameRouting? { get set }
+    var listener: OffGameListener? { get set }
 }
 
 protocol OffGameViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener, LoggedInListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -22,7 +22,7 @@ protocol TicTacToeRouting: ViewableRouting {
 }
 
 protocol TicTacToePresentable: Presentable {
-    weak var listener: TicTacToePresentableListener? { get set }
+    var listener: TicTacToePresentableListener? { get set }
     func setCell(atRow row: Int, col: Int, withPlayerType playerType: PlayerType)
     func announce(winner: PlayerType)
 }

--- a/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeRouter.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol TicTacToeInteractable: Interactable {
-    weak var router: TicTacToeRouting? { get set }
-    weak var listener: TicTacToeListener? { get set }
+    var router: TicTacToeRouting? { get set }
+    var listener: TicTacToeListener? { get set }
 }
 
 protocol TicTacToeViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedInInteractable: Interactable, OffGameListener, GameListener {
-    weak var router: LoggedInRouting? { get set }
-    weak var listener: LoggedInListener? { get set }
+    var router: LoggedInRouting? { get set }
+    var listener: LoggedInListener? { get set }
 }
 
 protocol LoggedInViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -22,7 +22,7 @@ protocol LoggedOutRouting: ViewableRouting {
 }
 
 protocol LoggedOutPresentable: Presentable {
-    weak var listener: LoggedOutPresentableListener? { get set }
+    var listener: LoggedOutPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedOutInteractable: Interactable {
-    weak var router: LoggedOutRouting? { get set }
-    weak var listener: LoggedOutListener? { get set }
+    var router: LoggedOutRouting? { get set }
+    var listener: LoggedOutListener? { get set }
 }
 
 protocol LoggedOutViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameInteractor.swift
@@ -22,7 +22,7 @@ protocol OffGameRouting: ViewableRouting {
 }
 
 protocol OffGamePresentable: Presentable {
-    weak var listener: OffGamePresentableListener? { get set }
+    var listener: OffGamePresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol OffGameInteractable: Interactable, BasicScoreBoardListener {
-    weak var router: OffGameRouting? { get set }
-    weak var listener: OffGameListener? { get set }
+    var router: OffGameRouting? { get set }
+    var listener: OffGameListener? { get set }
 }
 
 protocol OffGameViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinInteractor.swift
@@ -22,7 +22,7 @@ public protocol RandomWinRouting: ViewableRouting {
 }
 
 protocol RandomWinPresentable: Presentable {
-    weak var listener: RandomWinPresentableListener? { get set }
+    var listener: RandomWinPresentableListener? { get set }
     func announce(winner: PlayerType, withCompletionHandler handler: @escaping () -> ())
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RandomWinInteractable: Interactable {
-    weak var router: RandomWinRouting? { get set }
-    weak var listener: RandomWinListener? { get set }
+    var router: RandomWinRouting? { get set }
+    var listener: RandomWinListener? { get set }
 }
 
 protocol RandomWinViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener, LoggedInListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
@@ -22,7 +22,7 @@ public protocol BasicScoreBoardRouting: ViewableRouting {
 }
 
 protocol BasicScoreBoardPresentable: Presentable {
-    weak var listener: BasicScoreBoardPresentableListener? { get set }
+    var listener: BasicScoreBoardPresentableListener? { get set }
     func set(score: Score)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol BasicScoreBoardInteractable: Interactable {
-    weak var router: BasicScoreBoardRouting? { get set }
-    weak var listener: BasicScoreBoardListener? { get set }
+    var router: BasicScoreBoardRouting? { get set }
+    var listener: BasicScoreBoardListener? { get set }
 }
 
 protocol BasicScoreBoardViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -22,7 +22,7 @@ public protocol TicTacToeRouting: ViewableRouting {
 }
 
 protocol TicTacToePresentable: Presentable {
-    weak var listener: TicTacToePresentableListener? { get set }
+    var listener: TicTacToePresentableListener? { get set }
     func setCell(atRow row: Int, col: Int, withPlayerType playerType: PlayerType)
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeRouter.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol TicTacToeInteractable: Interactable {
-    weak var router: TicTacToeRouting? { get set }
-    weak var listener: TicTacToeListener? { get set }
+    var router: TicTacToeRouting? { get set }
+    var listener: TicTacToeListener? { get set }
 }
 
 protocol TicTacToeViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedInInteractable: Interactable, OffGameListener, GameListener {
-    weak var router: LoggedInRouting? { get set }
-    weak var listener: LoggedInListener? { get set }
+    var router: LoggedInRouting? { get set }
+    var listener: LoggedInListener? { get set }
 }
 
 protocol LoggedInViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -22,7 +22,7 @@ protocol LoggedOutRouting: ViewableRouting {
 }
 
 protocol LoggedOutPresentable: Presentable {
-    weak var listener: LoggedOutPresentableListener? { get set }
+    var listener: LoggedOutPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol LoggedOutInteractable: Interactable {
-    weak var router: LoggedOutRouting? { get set }
-    weak var listener: LoggedOutListener? { get set }
+    var router: LoggedOutRouting? { get set }
+    var listener: LoggedOutListener? { get set }
 }
 
 protocol LoggedOutViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameInteractor.swift
@@ -22,7 +22,7 @@ protocol OffGameRouting: ViewableRouting {
 }
 
 protocol OffGamePresentable: Presentable {
-    weak var listener: OffGamePresentableListener? { get set }
+    var listener: OffGamePresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol OffGameInteractable: Interactable, BasicScoreBoardListener {
-    weak var router: OffGameRouting? { get set }
-    weak var listener: OffGameListener? { get set }
+    var router: OffGameRouting? { get set }
+    var listener: OffGameListener? { get set }
 }
 
 protocol OffGameViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinInteractor.swift
@@ -22,7 +22,7 @@ public protocol RandomWinRouting: ViewableRouting {
 }
 
 protocol RandomWinPresentable: Presentable {
-    weak var listener: RandomWinPresentableListener? { get set }
+    var listener: RandomWinPresentableListener? { get set }
     func announce(winner: PlayerType, withCompletionHandler handler: @escaping () -> ())
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RandomWinInteractable: Interactable {
-    weak var router: RandomWinRouting? { get set }
-    weak var listener: RandomWinListener? { get set }
+    var router: RandomWinRouting? { get set }
+    var listener: RandomWinListener? { get set }
 }
 
 protocol RandomWinViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Root/RootInteractor.swift
@@ -22,7 +22,7 @@ protocol RootRouting: ViewableRouting {
 }
 
 protocol RootPresentable: Presentable {
-    weak var listener: RootPresentableListener? { get set }
+    var listener: RootPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/Root/RootRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Root/RootRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol RootInteractable: Interactable, LoggedOutListener, LoggedInListener {
-    weak var router: RootRouting? { get set }
-    weak var listener: RootListener? { get set }
+    var router: RootRouting? { get set }
+    var listener: RootListener? { get set }
 }
 
 protocol RootViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
@@ -22,7 +22,7 @@ public protocol BasicScoreBoardRouting: ViewableRouting {
 }
 
 protocol BasicScoreBoardPresentable: Presentable {
-    weak var listener: BasicScoreBoardPresentableListener? { get set }
+    var listener: BasicScoreBoardPresentableListener? { get set }
     func set(score: Score)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol BasicScoreBoardInteractable: Interactable {
-    weak var router: BasicScoreBoardRouting? { get set }
-    weak var listener: BasicScoreBoardListener? { get set }
+    var router: BasicScoreBoardRouting? { get set }
+    var listener: BasicScoreBoardListener? { get set }
 }
 
 protocol BasicScoreBoardViewControllable: ViewControllable {

--- a/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -22,7 +22,7 @@ public protocol TicTacToeRouting: ViewableRouting {
 }
 
 protocol TicTacToePresentable: Presentable {
-    weak var listener: TicTacToePresentableListener? { get set }
+    var listener: TicTacToePresentableListener? { get set }
     func setCell(atRow row: Int, col: Int, withPlayerType playerType: PlayerType)
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }

--- a/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeRouter.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeRouter.swift
@@ -17,8 +17,8 @@
 import RIBs
 
 protocol TicTacToeInteractable: Interactable {
-    weak var router: TicTacToeRouting? { get set }
-    weak var listener: TicTacToeListener? { get set }
+    var router: TicTacToeRouting? { get set }
+    var listener: TicTacToeListener? { get set }
 }
 
 protocol TicTacToeViewControllable: ViewControllable {


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
* Removing `weak` from property declarations in protocols. Removed from both the Xcode templates and tutorials.
* Removes the warning in Xcode 9.3, `'weak' should not be applied to a property declaration in a protocol and will be disallowed in future versions`
* https://github.com/apple/swift-evolution/blob/master/proposals/0186-remove-ownership-keyword-support-in-protocols.md
* Maybe a couple changes needed on the wiki? I don't know how to edit the wiki.
<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: N/A

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
