### PR TITLE
Fixed typo on POM artifact id for rib-debug-utils

### DIFF
--- a/android/libraries/rib-debug-utils/gradle.properties
+++ b/android/libraries/rib-debug-utils/gradle.properties
@@ -15,5 +15,5 @@
 #
 
 POM_NAME=RIBs (Debug Utils)
-POM_ARTIFACT_ID=rib-debut-utils
+POM_ARTIFACT_ID=rib-debug-utils
 POM_PACKAGING=jar


### PR DESCRIPTION
**Description**: Fixed typo on the POM artifact id for the Android debug utils
