### PR TITLE
[WIP] LaunchRouter now will come with UIWindow

### DIFF
--- a/ios/RIBs/Classes/LaunchRouter.swift
+++ b/ios/RIBs/Classes/LaunchRouter.swift
@@ -34,7 +34,7 @@ open class LaunchRouter<InteractorType>: Router<InteractorType>, LaunchRouting {
     /// - parameter window: The corresponding `UIWindow` of this `Router`.
     private weak var window: UIWindow?
 
-    public override init(interactor: InteractorType, window: UIWindow) {
+    public init(interactor: InteractorType, window: UIWindow) {
         self.window = window
         window.makeKeyAndVisible()
         super.init(interactor: interactor)

--- a/ios/RIBs/Classes/LaunchRouter.swift
+++ b/ios/RIBs/Classes/LaunchRouter.swift
@@ -17,33 +17,36 @@
 import UIKit
 
 /// The root `Router` of an application.
-public protocol LaunchRouting: ViewableRouting {
+public protocol LaunchRouting: Routing {
 
     /// Launches the router tree.
     ///
     /// - parameter window: The application window to launch from.
-    func launch(from window: UIWindow)
+    func show(viewController: UIViewController)
 }
 
 /// The application root router base class, that acts as the root of the router tree.
-open class LaunchRouter<InteractorType, ViewControllerType>: ViewableRouter<InteractorType, ViewControllerType>, LaunchRouting {
+open class LaunchRouter<InteractorType>: Router<InteractorType>, LaunchRouting {
 
     /// Initializer.
     ///
     /// - parameter interactor: The corresponding `Interactor` of this `Router`.
-    /// - parameter viewController: The corresponding `ViewController` of this `Router`.
-    public override init(interactor: InteractorType, viewController: ViewControllerType) {
-        super.init(interactor: interactor, viewController: viewController)
-    }
+    /// - parameter window: The corresponding `UIWindow` of this `Router`.
+    private weak var window: UIWindow?
 
-    /// Launches the router tree.
-    ///
-    /// - parameter window: The window to launch the router tree in.
-    public final func launch(from window: UIWindow) {
-        window.rootViewController = viewControllable.uiviewController
+    public override init(interactor: InteractorType, window: UIWindow) {
+        self.window = window
         window.makeKeyAndVisible()
-
+        super.init(interactor: interactor)
+        
         interactable.activate()
         load()
+    }
+
+    /// Set root UIViewController.
+    ///
+    /// - parameter viewController: The viewController to be set as root of UIWindow.
+    public final func show(viewController: UIViewController) {
+        window?.rootViewController = viewController
     }
 }

--- a/ios/RIBsTests/LaunchRouterTests.swift
+++ b/ios/RIBsTests/LaunchRouterTests.swift
@@ -22,7 +22,7 @@ final class LaunchRouterTests: XCTestCase {
     private var launchRouter: LaunchRouting!
 
     private var interactor: InteractableMock!
-    private var viewController: ViewControllableMock!
+    private var window: WindowMock!
 
     // MARK: - Setup
 
@@ -30,15 +30,15 @@ final class LaunchRouterTests: XCTestCase {
         super.setUp()
 
         interactor = InteractableMock()
-        viewController = ViewControllableMock()
-        launchRouter = LaunchRouter(interactor: interactor, viewController: viewController)
+        window = WindowMock()
+        launchRouter = LaunchRouter(interactor: interactor, window: window)
     }
 
     // MARK: - Tests
 
     func test_launchFromWindow() {
-        let window = WindowMock(frame: .zero)
-        launchRouter.launch(from: window)
+        let viewController = ViewControllableMock()
+        launchRouter.show(viewController: viewController)
 
         XCTAssert(window.rootViewController === viewController.uiviewController)
         XCTAssert(window.isKeyWindow)

--- a/ios/RIBsTests/LaunchRouterTests.swift
+++ b/ios/RIBsTests/LaunchRouterTests.swift
@@ -36,7 +36,7 @@ final class LaunchRouterTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_launchFromWindow() {
+    func test_showViewController() {
         let viewController = ViewControllableMock()
         launchRouter.show(viewController: viewController.uiviewController)
 

--- a/ios/RIBsTests/LaunchRouterTests.swift
+++ b/ios/RIBsTests/LaunchRouterTests.swift
@@ -38,7 +38,7 @@ final class LaunchRouterTests: XCTestCase {
 
     func test_launchFromWindow() {
         let viewController = ViewControllableMock()
-        launchRouter.show(viewController: viewController)
+        launchRouter.show(viewController: viewController.uiviewController)
 
         XCTAssert(window.rootViewController === viewController.uiviewController)
         XCTAssert(window.isKeyWindow)


### PR DESCRIPTION
This PR related to issue #281.

**Description**:
This will replace UIViewController by UIWindow in LaunchRouter. This will help we create View Hierarchy as before: SignIn/Home/Main... will be set as UIWindow.rootViewController. They will no longer be present from RootViewController.

In a short way, RootViewController now becomes a UIWindow.

