### PR TITLE
[ios/tooling] install-xcode-template respects the `xcode-select`ed Xcode

### DIFF
--- a/ios/tooling/install-xcode-template.sh
+++ b/ios/tooling/install-xcode-template.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
 
 # Configuration
-XCODE_TEMPLATE_DIR=$HOME'/Library/Developer/Xcode/Templates/File Templates/RIBs'
+MY_XCODE_PATH="$(xcode-select -p)"
+XCODE_SELECT_PATH_SUFFIX='/Contents/Developer' # xcode-select -p includes this after the path we need to append templates to
+TEMPLATE_DIR_PATH_SUFFIX='/Templates/File Templates/RIBs'
+XCODE_TEMPLATE_DIR="$(echo ${MY_XCODE_PATH/$XCODE_SELECT_PATH_SUFFIX/$TEMPLATE_DIR_PATH_SUFFIX})"
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Copy RIBs file templates into the local RIBs template directory


### PR DESCRIPTION
I'm not a bash pro, please patch this to be less terrible if it is. I tested on my computer and this correctly output the template path relative to my `xcode-select`ed Xcode