### PR TITLE
Remove use of soon to be deprecated Variable

### DIFF
--- a/ios/RIBs/Classes/LeakDetector/LeakDetector.swift
+++ b/ios/RIBs/Classes/LeakDetector/LeakDetector.swift
@@ -194,3 +194,4 @@ fileprivate class LeakDetectionHandleImpl: LeakDetectionHandle {
         cancelClosure?()
     }
 }
+


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
From RxSwift 4.0, Variable is marked as DEPRECATED and will be removed soon. This change removes the use of `Variable` in `LeakDetector` and instead uses an ivar which pushes to a `ReplaySubject` in `didSet`. The behavior with this change should match the current `Variable` approach exactly.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/RIBs/issues/287

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
There are no unit tests for `LeakDetector`. 
