### PR TITLE
Add default implementation to LaunchRouting

### DIFF
--- a/ios/RIBs/Classes/LaunchRouter.swift
+++ b/ios/RIBs/Classes/LaunchRouter.swift
@@ -25,6 +25,20 @@ public protocol LaunchRouting: ViewableRouting {
     func launch(from window: UIWindow)
 }
 
+public extension LaunchRouting {
+
+    /// Launches the router tree.
+    ///
+    /// - parameter window: The window to launch the router tree in.
+    public func launch(from window: UIWindow) {
+        window.rootViewController = viewControllable.uiviewController
+        window.makeKeyAndVisible()
+
+        interactable.activate()
+        load()
+    }
+}
+
 /// The application root router base class, that acts as the root of the router tree.
 open class LaunchRouter<InteractorType, ViewControllerType>: ViewableRouter<InteractorType, ViewControllerType>, LaunchRouting {
 
@@ -34,16 +48,5 @@ open class LaunchRouter<InteractorType, ViewControllerType>: ViewableRouter<Inte
     /// - parameter viewController: The corresponding `ViewController` of this `Router`.
     public override init(interactor: InteractorType, viewController: ViewControllerType) {
         super.init(interactor: interactor, viewController: viewController)
-    }
-
-    /// Launches the router tree.
-    ///
-    /// - parameter window: The window to launch the router tree in.
-    public final func launch(from window: UIWindow) {
-        window.rootViewController = viewControllable.uiviewController
-        window.makeKeyAndVisible()
-
-        interactable.activate()
-        load()
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Add default implementation to LaunchRouting. By doing this, we can use it for custom routers and not restricted to use LaunchRouter.
Mainly I moved the implementation from LaunchRouter to be a default implementation in for LaunchRouting.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. 
**Related issue(s)**:
-->
<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
