### PR TITLE
Activate children RIBs when attaching only if parent is active

### DIFF
--- a/ios/RIBs/Classes/Router.swift
+++ b/ios/RIBs/Classes/Router.swift
@@ -137,7 +137,9 @@ open class Router<InteractorType>: Routing {
 
         // Activate child first before loading. Router usually attaches immutable children in didLoad.
         // We need to make sure the RIB is activated before letting it attach immutable children.
-        child.interactable.activate()
+        if interactable.isActive {
+            child.interactable.activate()
+        }
         child.load()
     }
 

--- a/ios/RIBsTests/RouterTests.swift
+++ b/ios/RIBsTests/RouterTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class RouterTests: XCTestCase {
 
     private var router: Router<Interactable>!
-    private var lifecycleDisposable: Disposable!
+    private var lifecycleDisposable: Disposable?
 
     // MARK: - Setup
 
@@ -33,8 +33,7 @@ final class RouterTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-
-        lifecycleDisposable.dispose()
+        lifecycleDisposable?.dispose()
     }
 
     // MARK: - Tests
@@ -64,4 +63,46 @@ final class RouterTests: XCTestCase {
         XCTAssertNil(currentLifecycle)
         XCTAssertTrue(didComplete)
     }
+
+    func test_attachingChildToInactiveRIB() {
+        let parentInteractor = InteractorMock()
+        let parentRouter = Router(interactor: parentInteractor)
+        parentRouter.load()
+
+        let childInteractor = InteractorMock()
+        let childRouter = Router(interactor: childInteractor)
+        parentRouter.attachChild(childRouter)
+
+        XCTAssertFalse(childRouter.interactable.isActive)
+
+        parentInteractor.activate()
+
+        XCTAssertTrue(childInteractor.isActive)
+
+        parentInteractor.deactivate()
+
+        XCTAssertFalse(childInteractor.isActive)
+    }
+
+    func test_attachingChildToActiveRIB() {
+        let parentInteractor = InteractorMock()
+        let parentRouter = Router(interactor: parentInteractor)
+        parentInteractor.activate()
+        parentRouter.load()
+
+        let childInteractor = InteractorMock()
+        let childRouter = Router(interactor: childInteractor)
+        parentRouter.attachChild(childRouter)
+
+        XCTAssertTrue(childRouter.interactable.isActive)
+
+        parentInteractor.deactivate()
+
+        XCTAssertFalse(childInteractor.isActive)
+
+        parentInteractor.activate()
+
+        XCTAssertTrue(childInteractor.isActive)
+    }
+
 }


### PR DESCRIPTION
I wanted to prepare RIBs hierarchy in advance without attaching parent router but I found out children RIBs get activated on `attachChild` even though parent RIB isn't.
Was there any specific reason it was done this way?