### PR TITLE
Add new builder classes compatible with Needle

### DIFF
--- a/ios/RIBs/Classes/ComponentizedBuilder.swift
+++ b/ios/RIBs/Classes/ComponentizedBuilder.swift
@@ -1,0 +1,145 @@
+//
+//  Copyright (c) 2017. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Utility that instantiates a RIB and sets up its internal wirings.
+/// This class ensures the strict one to one relationship between a
+/// new instance of the RIB and a single new instance of the component.
+/// Every time a new RIB is built a new instance of the corresponding
+/// component is also instantiated.
+///
+/// This is the most generic version of the builder class that supports
+/// both dynamic dependencies injected when building the RIB as well
+/// as dynamic dependencies for instantiating the component. For more
+/// convenient base class, please refer to `SimpleComponentizedBuilder`.
+///
+/// - note: Subclasses should override the `build(with)` method to
+/// implement the actual RIB building logic, with the given component
+/// and dynamic dependency.
+/// - SeeAlso: SimpleComponentizedBuilder
+open class ComponentizedBuilder<Component, Router, DynamicBuildDependency, DynamicComponentDependency>: Buildable {
+
+    // Builder should not directly retain an instance of the component.
+    // That would make the component's lifecycle longer than the built
+    // RIB. Instead, whenever a new instance of the RIB is built, a new
+    // instance of the DI component should also be instantiated.
+
+    /// Initializer.
+    ///
+    /// - parameter componentBuilder: The closure to instantiate a new
+    /// instance of the DI component that should be paired with this RIB.
+    public init(componentBuilder: @escaping (DynamicComponentDependency) -> Component) {
+        self.componentBuilder = componentBuilder
+    }
+
+    /// Build a new instance of the RIB with the given dynamic dependencies.
+    ///
+    /// - parameter dynamicBuildDependency: The dynamic dependency to use
+    /// to build the RIB.
+    /// - parameter dynamicComponentDependency: The dynamic dependency to
+    /// use to instantiate the component.
+    /// - returns: The router of the RIB.
+    public final func build(withDynamicBuildDependency dynamicBuildDependency: DynamicBuildDependency, dynamicComponentDependency: DynamicComponentDependency) -> Router {
+        return build(withDynamicBuildDependency: dynamicBuildDependency, dynamicComponentDependency: dynamicComponentDependency).1
+    }
+
+    /// Build a new instance of the RIB with the given dynamic dependencies.
+    ///
+    /// - parameter dynamicBuildDependency: The dynamic dependency to use
+    /// to build the RIB.
+    /// - parameter dynamicComponentDependency: The dynamic dependency to
+    /// use to instantiate the component.
+    /// - returns: The tuple of component and router of the RIB.
+    public final func build(withDynamicBuildDependency dynamicBuildDependency: DynamicBuildDependency, dynamicComponentDependency: DynamicComponentDependency) -> (Component, Router) {
+        let component = componentBuilder(dynamicComponentDependency)
+
+        // Ensure each componentBuilder invocation produces a new component
+        // instance.
+        let newComponent = component as AnyObject
+        if lastComponent === newComponent {
+            assertionFailure("\(self) componentBuilder should produce new instances of component when build is invoked.")
+        }
+        lastComponent = newComponent
+
+        return (component, build(with: component, dynamicBuildDependency))
+    }
+
+    /// Abstract method that must be overriden to implement the RIB building
+    /// logic using the given component and dynamic dependency.
+    ///
+    /// - note: This method should never be invoked directly. Instead
+    /// consumers of this builder should invoke `build(with dynamicDependency:)`.
+    /// - parameter component: The corresponding DI component to use.
+    /// - parameter dynamicBuildDependency: The given dynamic dependency.
+    /// - returns: The router of the RIB.
+    open func build(with component: Component, _ dynamicBuildDependency: DynamicBuildDependency) -> Router {
+        fatalError("This method should be oevrriden by the subclass.")
+    }
+
+    // MARK: - Private
+
+    private let componentBuilder: (DynamicComponentDependency) -> Component
+    private weak var lastComponent: AnyObject?
+}
+
+/// A convenient base builder class that does not require any build or
+/// component dynamic dependencies.
+///
+/// - note: If the build method requires dynamic dependency, please
+/// refer to `DynamicBuildComponentizedBuilder`. If component instantiation
+/// requires dynamic dependency, please refer to `DynamicComponentizedBuilder`.
+/// If both require dynamic dependencies, please use `ComponentizedBuilder`.
+/// - SeeAlso: ComponentizedBuilder
+open class SimpleComponentizedBuilder<Component, Router>: ComponentizedBuilder<Component, Router, (), ()> {
+
+    /// Initializer.
+    ///
+    /// - parameter componentBuilder: The closure to instantiate a new
+    /// instance of the DI component that should be paired with this RIB.
+    #if compiler(>=5.0)
+        public init(componentBuilder: @escaping () -> Component) {
+            super.init(componentBuilder: componentBuilder)
+        }
+    #else
+        public override init(componentBuilder: @escaping () -> Component) {
+            super.init(componentBuilder: componentBuilder)
+        }
+    #endif
+
+    /// This method should not be directly invoked.
+    public final override func build(with component: Component, _ dynamicDependency: ()) -> Router {
+        return build(with: component)
+    }
+
+    /// Abstract method that must be overriden to implement the RIB building
+    /// logic using the given component.
+    ///
+    /// - note: This method should never be invoked directly. Instead
+    /// consumers of this builder should invoke `build(with dynamicDependency:)`.
+    /// - parameter component: The corresponding DI component to use.
+    /// - returns: The router of the RIB.
+    open func build(with component: Component) -> Router {
+        fatalError("This method should be oevrriden by the subclass.")
+    }
+
+    /// Build a new instance of the RIB.
+    ///
+    /// - returns: The router of the RIB.
+    public final func build() -> Router {
+        return build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
+    }
+}

--- a/ios/RIBs/Classes/MultiStageComponentizedBuilder.swift
+++ b/ios/RIBs/Classes/MultiStageComponentizedBuilder.swift
@@ -1,0 +1,145 @@
+//
+//  Copyright (c) 2017. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The base class of a builder that involves multiple stages of building
+/// a RIB. Witin the same pass, accesses to the component property shares
+/// the same instance. Once `finalStageBuild` is invoked, a new instance
+/// is returned from the component property, representing a new pass of
+/// the multi-stage building process.
+///
+/// - SeeAlso: SimpleMultiStageComponentizedBuilder
+open class MultiStageComponentizedBuilder<Component, Router, DynamicBuildDependency>: Buildable {
+
+    // Builder should not directly retain an instance of the component.
+    // That would make the component's lifecycle longer than the built
+    // RIB. Instead, whenever a new instance of the RIB is built, a new
+    // instance of the DI component should also be instantiated.
+
+    /// The DI component used for the current iteration of the multi-
+    /// stage build process. Once `finalStageBuild` method is invoked,
+    /// this property returns a separate new instance representing a
+    /// new pass of the multi-stage building process.
+    public var componentForCurrentBuildPass: Component {
+        if let currentPassComponent = currentPassComponent {
+            return currentPassComponent
+        } else {
+            let currentPassComponent = componentBuilder()
+
+            // Ensure each invocation of componentBuilder produces a new
+            // component instance.
+            let newComponent = currentPassComponent as AnyObject
+            if lastComponent === newComponent {
+                assertionFailure("\(self) componentBuilder should produce new instances of component when build is invoked.")
+            }
+            lastComponent = newComponent
+
+            self.currentPassComponent = currentPassComponent
+            return currentPassComponent
+        }
+    }
+
+    /// Initializer.
+    ///
+    /// - parameter componentBuilder: The closure to instantiate a new
+    /// instance of the DI component that should be paired with this RIB.
+    public init(componentBuilder: @escaping () -> Component) {
+        self.componentBuilder = componentBuilder
+    }
+
+    /// Build a new instance of the RIB with the given dynamic dependency
+    /// as the last stage of this mult-stage building process.
+    ///
+    /// - note: Subsequent access to the `component` property after this
+    /// method is returned will result in a separate new instance of the
+    /// component, representing a new pass of the multi-stage building
+    /// process.
+    /// - parameter dynamicDependency: The dynamic dependency to use.
+    /// - returns: The router of the RIB.
+    public final func finalStageBuild(withDynamicDependency dynamicDependency: DynamicBuildDependency) -> Router {
+        let router = finalStageBuild(with: componentForCurrentBuildPass, dynamicDependency)
+        defer {
+            currentPassComponent = nil
+        }
+        return router
+    }
+
+    /// Abstract method that must be overriden to implement the RIB building
+    /// logic using the given component and dynamic dependency, as the last
+    /// building stage.
+    ///
+    /// - note: This method should never be invoked directly. Instead
+    /// consumers of this builder should invoke `finalStageBuild(with dynamicDependency:)`.
+    /// - parameter component: The corresponding DI component to use.
+    /// - parameter dynamicDependency: The given dynamic dependency.
+    /// - returns: The router of the RIB.
+    open func finalStageBuild(with component: Component, _ dynamicDependency: DynamicBuildDependency) -> Router {
+        fatalError("This method should be oevrriden by the subclass.")
+    }
+
+    // MARK: - Private
+
+    private let componentBuilder: () -> Component
+    private var currentPassComponent: Component?
+    private weak var lastComponent: AnyObject?
+}
+
+/// A convenient base multi-stage builder class that does not require any
+/// build dynamic dependencies.
+///
+/// - note: If the build method requires dynamic dependency, please
+/// refer to `MultiStageComponentizedBuilder`.
+///
+/// - SeeAlso: MultiStageComponentizedBuilder
+open class SimpleMultiStageComponentizedBuilder<Component, Router>: MultiStageComponentizedBuilder<Component, Router, ()> {
+
+    /// Initializer.
+    ///
+    /// - parameter componentBuilder: The closure to instantiate a new
+    /// instance of the DI component that should be paired with this RIB.
+    public override init(componentBuilder: @escaping () -> Component) {
+        super.init(componentBuilder: componentBuilder)
+    }
+
+    /// This method should not be directly invoked.
+    public final override func finalStageBuild(with component: Component, _ dynamicDependency: ()) -> Router {
+        return finalStageBuild(with: component)
+    }
+
+    /// Abstract method that must be overriden to implement the RIB building
+    /// logic using the given component.
+    ///
+    /// - note: This method should never be invoked directly. Instead
+    /// consumers of this builder should invoke `finalStageBuild()`.
+    /// - parameter component: The corresponding DI component to use.
+    /// - returns: The router of the RIB.
+    open func finalStageBuild(with component: Component) -> Router {
+        fatalError("This method should be oevrriden by the subclass.")
+    }
+
+    /// Build a new instance of the RIB as the last stage of this mult-
+    /// stage building process.
+    ///
+    /// - note: Subsequent access to the `component` property after this
+    /// method is returned will result in a separate new instance of the
+    /// component, representing a new pass of the multi-stage building
+    /// process.
+    /// - returns: The router of the RIB.
+    public final func finalStageBuild() -> Router {
+        return finalStageBuild(withDynamicDependency: ())
+    }
+}

--- a/ios/RIBsTests/ComponentizedBuilderTests.swift
+++ b/ios/RIBsTests/ComponentizedBuilderTests.swift
@@ -1,0 +1,63 @@
+//
+//  Copyright (c) 2017. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import RIBs
+import XCTest
+
+class ComponentizedBuilderTests: XCTestCase {
+
+    func test_componentForCurrentPass_builderReturnsSameInstance_verifyAssertion() {
+        let component = MockComponent()
+        let sameInstanceBuilder = MockComponentizedBuilder {
+            return component
+        }
+        sameInstanceBuilder.buildHandler = { component, _ in
+            return MockSimpleRouter()
+        }
+
+        let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
+
+        expectAssertionFailure {
+            let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
+        }
+    }
+
+    func test_componentForCurrentPass_builderReturnsNewInstance_verifyNoAssertion() {
+        let sameInstanceBuilder = MockComponentizedBuilder {
+            return MockComponent()
+        }
+        sameInstanceBuilder.buildHandler = { component, _ in
+            return MockSimpleRouter()
+        }
+
+        let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
+
+        let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
+    }
+}
+
+private class MockComponent {}
+
+private class MockSimpleRouter {}
+
+private class MockComponentizedBuilder: ComponentizedBuilder<MockComponent, MockSimpleRouter, (), ()> {
+
+    fileprivate var buildHandler: ((MockComponent, ()) -> MockSimpleRouter)?
+
+    override func build(with component: MockComponent, _ dynamicBuildDependency: ()) -> MockSimpleRouter {
+        return buildHandler!(component, dynamicBuildDependency)
+    }
+}

--- a/ios/RIBsTests/MultiStageComponentizedBuilderTests.swift
+++ b/ios/RIBsTests/MultiStageComponentizedBuilderTests.swift
@@ -1,0 +1,88 @@
+//
+//  Copyright (c) 2017. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import RIBs
+import XCTest
+
+class MultiStageComponentizedBuilderTests: XCTestCase {
+
+    private var builder: MockMultiStageComponentizedBuilder!
+
+    override func setUp() {
+        super.setUp()
+
+        builder = MockMultiStageComponentizedBuilder {
+            return MockComponent()
+        }
+    }
+
+    func test_componentForCurrentPass_samePass_verifySameInstance() {
+        var instance = builder.componentForCurrentBuildPass
+        for _ in 0 ..< 100 {
+            XCTAssertTrue(instance === builder.componentForCurrentBuildPass)
+            instance = builder.componentForCurrentBuildPass
+        }
+    }
+
+    func test_componentForCurrentPass_multiplePasses_verifyDifferentInstances() {
+        builder.finalStageBuildHandler = { component, dynamicDep in
+            XCTAssertEqual(dynamicDep, 92393)
+            return MockSimpleRouter()
+        }
+
+        let firstPassInstance = builder.componentForCurrentBuildPass
+
+        _ = builder.finalStageBuild(withDynamicDependency: 92393)
+
+        let secondPassInstance = builder.componentForCurrentBuildPass
+
+        XCTAssertFalse(firstPassInstance === secondPassInstance)
+    }
+
+    func test_componentForCurrentPass_builderReturnsSameInstance_verifyAssertion() {
+        let component = MockComponent()
+        let sameInstanceBuilder = MockMultiStageComponentizedBuilder {
+            return component
+        }
+        sameInstanceBuilder.finalStageBuildHandler = { component, dynamicDep in
+            XCTAssertEqual(dynamicDep, 92393)
+            return MockSimpleRouter()
+        }
+
+        _ = sameInstanceBuilder.finalStageBuild(withDynamicDependency: 92393)
+
+        expectAssertionFailure {
+            _ = sameInstanceBuilder.finalStageBuild(withDynamicDependency: 92393)
+        }
+
+        expectAssertionFailure {
+            _ = sameInstanceBuilder.componentForCurrentBuildPass
+        }
+    }
+}
+
+private class MockComponent {}
+
+private class MockSimpleRouter {}
+
+private class MockMultiStageComponentizedBuilder: MultiStageComponentizedBuilder<MockComponent, MockSimpleRouter, Int> {
+
+    fileprivate var finalStageBuildHandler: ((MockComponent, Int) -> MockSimpleRouter)?
+
+    override func finalStageBuild(with component: MockComponent, _ dynamicDependency: Int) -> MockSimpleRouter {
+        return finalStageBuildHandler!(component, dynamicDependency)
+    }
+}


### PR DESCRIPTION
Since Uber internally has fully migrated to [Needle](https://github.com/uber/needle/), these base builder classes were introduced to make RIBs more compatible.
