### PR TITLE
Support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ xcuserdata/
 
 # Swift Package Manager
 .build/
+Package.resolved
 
 # CocoaPods
 Pods/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RIBs",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(name: "RIBs", targets: ["RIBs"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.0.0")
+    ],
+    targets: [
+        .target(name: "RIBs", dependencies: ["RxSwift", "RxRelay"], path: "ios/RIBs")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ To integrate RIBs into your project using Carthage add the following to your `Ca
 github "uber/RIBs" ~> 0.9
 ```
 
+#### Swift Package Manager
+
+To integrate RIBs into your project using Swift Package Manager add the following to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/uber/RIBs.git", from: "0.9.3"),
+]
+```
+
 ## Related projects
 
 If you like RIBs, check out other related open source projects from our team:

--- a/ios/RIBs/Classes/DI/Component.swift
+++ b/ios/RIBs/Classes/DI/Component.swift
@@ -21,6 +21,9 @@
 ///
 /// A component subclass implementation should conform to child 'Dependency' protocols, defined by all of its immediate
 /// children.
+
+import Foundation
+
 open class Component<DependencyType>: Dependency {
 
     /// The dependency of this `Component`.

--- a/ios/RIBs/Classes/LeakDetector/Executor.swift
+++ b/ios/RIBs/Classes/LeakDetector/Executor.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+import Foundation
 import RxSwift
 
 public class Executor {

--- a/ios/RIBs/Classes/LeakDetector/LeakDetector.swift
+++ b/ios/RIBs/Classes/LeakDetector/LeakDetector.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+import UIKit
 import RxSwift
 import RxRelay
 


### PR DESCRIPTION
Adds support for the SPM now that you can specify a platform in the `Package.swift`.

This will require the project adds a new tag/release for v0.9.3.

I've added a couple imports so that it builds when using iOS frameworks - ``swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path\`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios13.0-simulator"``

Resolves #112 #106 
