### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To integrate the recommended minimum setup for RIBs add the following to your `b
 ```gradle
 dependencies {
   annotationProcessor 'com.uber.rib:rib-compiler-test:0.9.2'
-  compile 'com.uber.rib:rib-android:0.9.2'
-  testCompile 'com.uber.rib:rib-test-utils:0.9.2'
+  implementation 'com.uber.rib:rib-android:0.9.2'
+  testImplementation 'com.uber.rib:rib-test-utils:0.9.2'
 }
 ```
 


### PR DESCRIPTION
Replace the deprecated gradle dependency handlers i.e. `compile` and `testCompile` with `implementation` and `testImplementation`.
