### PR TITLE
Compatible with RxSwift 5.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 5.0
+github "ReactiveX/RxSwift" ~> 5.1

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "RIBs", targets: ["RIBs"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.0.1"),
+        .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.1.0"),
     ],
     targets: [
         .target(

--- a/RIBs.podspec
+++ b/RIBs.podspec
@@ -11,6 +11,6 @@ RIBs is the cross-platform architecture behind many mobile apps at Uber. This ar
   s.source           = { :git => 'https://github.com/uber/RIBs.git', :tag => 'v' + s.version.to_s }
   s.ios.deployment_target = '8.0'
   s.source_files = 'ios/RIBs/Classes/**/*'
-  s.dependency 'RxSwift', '~> 5.0'
-  s.dependency 'RxRelay', '~> 5.0'
+  s.dependency 'RxSwift', '~> 5.1'
+  s.dependency 'RxRelay', '~> 5.1'
 end


### PR DESCRIPTION

**Description**:
RxSwift 5.1 removes UIWebView Reactive Extensions due to [Apple's hard deprecation, starting April 2020](https://developer.apple.com/news/?id=12232019b) .

RIBs also should be compatible with RxSwift 5.1.