### PR TITLE
Replace deprecated type 'Variable' to 'BehaviorRelay' in iOS Tutorials

### DIFF
--- a/ios/tutorials/tutorial3-completed/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Models/ScoreStream.swift
@@ -15,6 +15,7 @@
 //
 
 import RxSwift
+import RxCocoa
 
 struct Score {
     let player1Score: Int
@@ -53,10 +54,10 @@ class ScoreStreamImpl: MutableScoreStream {
                 return Score(player1Score: currentScore.player1Score, player2Score: currentScore.player2Score + 1)
             }
         }()
-        variable.value = newScore
+        variable.accept(newScore)
     }
 
     // MARK: - Private
 
-    private let variable = Variable<Score>(Score(player1Score: 0, player2Score: 0))
+    private let variable = BehaviorRelay<Score>(value: Score(player1Score: 0, player2Score: 0))
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Models/ScoreStream.swift
@@ -15,6 +15,7 @@
 //
 
 import RxSwift
+import RxCocoa
 
 public struct Score {
     public let player1Score: Int
@@ -55,10 +56,10 @@ public class ScoreStreamImpl: MutableScoreStream {
                 return Score(player1Score: currentScore.player1Score, player2Score: currentScore.player2Score + 1)
             }
         }()
-        variable.value = newScore
+        variable.accept(newScore)
     }
 
     // MARK: - Private
 
-    private let variable = Variable<Score>(Score(player1Score: 0, player2Score: 0))
+    private let variable = BehaviorRelay<Score>(value: Score(player1Score: 0, player2Score: 0))
 }

--- a/ios/tutorials/tutorial4/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Models/ScoreStream.swift
@@ -15,6 +15,7 @@
 //
 
 import RxSwift
+import RxCocoa
 
 public struct Score {
     public let player1Score: Int
@@ -55,10 +56,10 @@ public class ScoreStreamImpl: MutableScoreStream {
                 return Score(player1Score: currentScore.player1Score, player2Score: currentScore.player2Score + 1)
             }
         }()
-        variable.value = newScore
+        variable.accept(newScore)
     }
 
     // MARK: - Private
 
-    private let variable = Variable<Score>(Score(player1Score: 0, player2Score: 0))
+    private let variable = BehaviorRelay<Score>(value: Score(player1Score: 0, player2Score: 0))
 }


### PR DESCRIPTION
**Description**:
`Variable` is deprecated but used in tutorial3-complete, tutorial4 and tutorial4-complete. Replaced it to `BehaviorRelay`.
