### PR TITLE
Renames tutorial comments spelling

### DIFF
--- a/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -127,7 +127,7 @@ final class TicTacToeInteractor: PresentableInteractor<TicTacToePresentable>, Ti
             }
         }
 
-        // Diagnals.
+        // Diagonal.
         guard let p11 = board[1][1] else {
             return nil
         }

--- a/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -125,7 +125,7 @@ final class TicTacToeInteractor: PresentableInteractor<TicTacToePresentable>, Ti
             }
         }
 
-        // Diagnals.
+        // Diagonal.
         guard let p11 = board[1][1] else {
             return nil
         }

--- a/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -127,7 +127,7 @@ final class TicTacToeInteractor: PresentableInteractor<TicTacToePresentable>, Ti
             }
         }
 
-        // Diagnals.
+        // Diagonal.
         guard let p11 = board[1][1] else {
             return nil
         }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -145,7 +145,7 @@ final class TicTacToeInteractor: PresentableInteractor<TicTacToePresentable>, Ti
             }
         }
 
-        // Diagnals.
+        // Diagonal.
         guard let p11 = board[1][1] else {
             return nil
         }

--- a/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -145,7 +145,7 @@ final class TicTacToeInteractor: PresentableInteractor<TicTacToePresentable>, Ti
             }
         }
 
-        // Diagnals.
+        // Diagonal.
         guard let p11 = board[1][1] else {
             return nil
         }


### PR DESCRIPTION
**Description**: Modifying 'Diagnals' in iOS tutorial comments to 'Diagonal'