### PR TITLE
Migrate from AssertJ to Truth

### DIFF
--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -76,8 +76,8 @@ def androidx = [
 def test = [
     junit: "junit:junit:4.12",
     mockito: "org.mockito:mockito-core:2.0.42-beta",
-    assertj: "org.assertj:assertj-core:2.6.0",
     compileTesting: "com.google.testing.compile:compile-testing:0.17",
+    truth: "com.google.truth:truth:0.43",
 ]
 
 def external = [

--- a/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/BundleTest.java
+++ b/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/BundleTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 public class BundleTest {

--- a/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/RibActivityTest.java
+++ b/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/RibActivityTest.java
@@ -41,7 +41,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 
 import static com.uber.autodispose.AutoDispose.autoDisposable;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Robolectric.buildActivity;

--- a/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/ViewBuilderTest.java
+++ b/android/libraries/rib-android-test/src/test/java/com/uber/rib/core/ViewBuilderTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 public class ViewBuilderTest {

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     testCompile deps.apt.androidApi
     testCompile deps.test.junit
     testCompile deps.test.mockito
-    testCompile deps.test.assertj
+    testCompile deps.test.truth
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/libraries/rib-base/src/test/java/com/uber/rib/core/InteractorAndRouterTest.java
+++ b/android/libraries/rib-base/src/test/java/com/uber/rib/core/InteractorAndRouterTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;

--- a/android/libraries/rib-base/src/test/java/com/uber/rib/core/RecordingObserver.java
+++ b/android/libraries/rib-base/src/test/java/com/uber/rib/core/RecordingObserver.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * RecordingObserver implementation from RxBinding.

--- a/android/libraries/rib-base/src/test/java/com/uber/rib/core/RouterTest.java
+++ b/android/libraries/rib-base/src/test/java/com/uber/rib/core/RouterTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class RouterTest {

--- a/android/libraries/rib-base/src/test/java/com/uber/rib/core/WorkerBinderTest.java
+++ b/android/libraries/rib-base/src/test/java/com/uber/rib/core/WorkerBinderTest.java
@@ -32,7 +32,7 @@ import io.reactivex.Maybe;
 import io.reactivex.functions.Consumer;
 
 import static com.uber.rib.core.WorkerBinder.bind;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/android/libraries/rib-router-navigator/build.gradle
+++ b/android/libraries/rib-router-navigator/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     testCompile deps.test.junit
     testCompile deps.test.mockito
-    testCompile deps.test.assertj
+    testCompile deps.test.truth
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/libraries/rib-router-navigator/src/test/java/com/uber/rib/core/ModernRouterNavigatorTest.java
+++ b/android/libraries/rib-router-navigator/src/test/java/com/uber/rib/core/ModernRouterNavigatorTest.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/android/libraries/rib-test-utils/build.gradle
+++ b/android/libraries/rib-test-utils/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compileOnly deps.androidx.annotations
     compile deps.external.rxjava2
     compile deps.test.junit
-    compile deps.test.assertj
+    compile deps.test.truth
     compile deps.test.mockito
 }
 

--- a/android/libraries/rib-test-utils/src/main/java/com/uber/rib/core/AndroidRecordingRx2Observer.java
+++ b/android/libraries/rib-test-utils/src/main/java/com/uber/rib/core/AndroidRecordingRx2Observer.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * AndroidRecordingObserver implementation from RxBinding.

--- a/android/libraries/rib-workflow-test/build.gradle
+++ b/android/libraries/rib-workflow-test/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     api project(":libraries:rib-workflow")
     api deps.external.guavaAndroid
     api deps.external.rxjava2
-    implementation deps.test.assertj
+    implementation deps.test.truth
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/libraries/rib-workflow-test/src/main/java/com/uber/rib/workflow/core/StepTester.java
+++ b/android/libraries/rib-workflow-test/src/main/java/com/uber/rib/workflow/core/StepTester.java
@@ -15,12 +15,12 @@
  */
 package com.uber.rib.workflow.core;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import androidx.annotation.Nullable;
 import com.google.common.base.Optional;
 import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
-
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 /** Utility to expose {@link Observable} instances on a {@link Step} for unit testing purposes. */
 public final class StepTester {

--- a/android/libraries/rib-workflow/build.gradle
+++ b/android/libraries/rib-workflow/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     api deps.external.rxjava2
     api project(":libraries:rib-android")
     testImplementation deps.test.junit
-    testImplementation deps.test.assertj
+    testImplementation deps.test.truth
     testImplementation deps.test.mockito
 }
 

--- a/android/libraries/rib-workflow/src/main/java/com/uber/rib/workflow/core/Step.java
+++ b/android/libraries/rib-workflow/src/main/java/com/uber/rib/workflow/core/Step.java
@@ -83,7 +83,8 @@ public class Step<T, A extends ActionableItem> {
    * @return a {@link Step} to chain more calls to.
    */
   @SuppressWarnings("RxJavaToSingle") // Replace singleOrError() with firstOrError()
-  public <T2, A2 extends ActionableItem> Step<T2, A2> onStep(Step<T, A> this, final BiFunction<T, A, Step<T2, A2>> func) {
+  public <T2, A2 extends ActionableItem> Step<T2, A2> onStep(
+      Step<T, A> this, final BiFunction<T, A, Step<T2, A2>> func) {
     return new Step<>(
         asObservable()
             .flatMap(

--- a/android/libraries/rib-workflow/src/test/java/com/uber/rib/workflow/core/StepTest.java
+++ b/android/libraries/rib-workflow/src/test/java/com/uber/rib/workflow/core/StepTest.java
@@ -15,6 +15,8 @@
  */
 package com.uber.rib.workflow.core;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.base.Optional;
 import com.uber.rib.core.lifecycle.InteractorEvent;
 import io.reactivex.Observable;
@@ -24,8 +26,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class StepTest {
   @Rule public final AndroidSchedulersRule androidSchedulersRuleRx2 = new AndroidSchedulersRule();
@@ -45,8 +45,7 @@ public class StepTest {
   @Test
   public void asObservable_withInactiveLifecycle_shouldWaitForActiveLifecycleBeforeEmitting() {
     Object returnValue = new Object();
-    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber =
-        new TestObserver<>();
+    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber = new TestObserver<>();
 
     step.asObservable().subscribe(testSubscriber);
 
@@ -73,8 +72,7 @@ public class StepTest {
   @Test
   public void asObservable_withActiveLifecycle_shouldEmitWithoutWaiting() {
     Object returnValue = new Object();
-    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber =
-        new TestObserver<>();
+    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber = new TestObserver<>();
 
     interactorLifecycleSubject.onNext(InteractorEvent.ACTIVE);
 
@@ -98,8 +96,7 @@ public class StepTest {
   public void onStep_withASuccessFullFirstAction_shouldProperlyChainTheNextStep() {
     Object returnValue = new Object();
     Object secondReturnValue = new Object();
-    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber =
-        new TestObserver<>();
+    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber = new TestObserver<>();
 
     interactorLifecycleSubject.onNext(InteractorEvent.ACTIVE);
 
@@ -123,15 +120,15 @@ public class StepTest {
 
   @Test
   public void onStep_withAnUnsuccessfulFirstAction_shouldTerminateTheWholeChain() {
-    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber =
-        new TestObserver<>();
+    TestObserver<Optional<Step.Data<Object, ActionableItem>>> testSubscriber = new TestObserver<>();
     Object secondReturnValue = new Object();
 
     interactorLifecycleSubject.onNext(InteractorEvent.ACTIVE);
 
     step.onStep(
             (o, actionableItem) ->
-                Step.from(Observable.just(new Step.Data<>(secondReturnValue, actionableItem))
+                Step.from(
+                    Observable.just(new Step.Data<>(secondReturnValue, actionableItem))
                         .singleOrError()))
         .asObservable()
         .subscribe(testSubscriber);

--- a/android/libraries/rib-workflow/src/test/java/com/uber/rib/workflow/core/WorkflowTest.java
+++ b/android/libraries/rib-workflow/src/test/java/com/uber/rib/workflow/core/WorkflowTest.java
@@ -15,6 +15,9 @@
  */
 package com.uber.rib.workflow.core;
 
+import static com.google.common.truth.Truth.assertThat;
+import static io.reactivex.android.plugins.RxAndroidPlugins.setInitMainThreadSchedulerHandler;
+
 import androidx.annotation.NonNull;
 import com.google.common.base.Optional;
 import com.uber.rib.core.lifecycle.InteractorEvent;
@@ -27,9 +30,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static io.reactivex.android.plugins.RxAndroidPlugins.setInitMainThreadSchedulerHandler;
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class WorkflowTest {
   @Rule public final AndroidSchedulersRule androidSchedulersRuleRx2 = new AndroidSchedulersRule();

--- a/android/tooling/rib-intellij-plugin/build.gradle
+++ b/android/tooling/rib-intellij-plugin/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     testCompile deps.external.dagger
     testCompile deps.uber.autodispose
     testCompile deps.uber.autodisposeLifecycle
-    testCompile deps.test.assertj
+    testCompile deps.test.truth
     testCompile deps.test.compileTesting
     testCompile deps.test.mockito
 }


### PR DESCRIPTION
This PR migrates RIBs over to Truth for unit test assertions. #392 

Changes the import path:
```diff
- import static org.assertj.core.api.Java6Assertions.assertThat;
+ import static com.google.common.truth.Truth.assertThat;
```

Changes the dependency:
```diff
- testCompile deps.test.assertj
+ testCompile deps.test.truth
```