### PR TITLE
Align app & test rib-compiler modules with internal versions

### DIFF
--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/ErrorReporter.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/ErrorReporter.java
@@ -16,7 +16,6 @@
 package com.uber.rib.compiler;
 
 import androidx.annotation.Nullable;
-
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/Generator.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/Generator.java
@@ -16,7 +16,6 @@
 package com.uber.rib.compiler;
 
 import java.io.IOException;
-
 import javax.annotation.processing.ProcessingEnvironment;
 
 /**

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/InteractorAnnotatedClass.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/InteractorAnnotatedClass.java
@@ -16,30 +16,36 @@
 package com.uber.rib.compiler;
 
 import com.uber.rib.core.RibBuilder;
-
 import java.util.List;
-
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
 /** Extension point for adding more information to a class annotated with {@link RibBuilder}. */
 public class InteractorAnnotatedClass extends AnnotatedClass {
 
-  private final List<VariableElement> injectFields;
+  private final List<? extends VariableElement> dependencies;
+  private final boolean isBasic;
 
-  public InteractorAnnotatedClass(TypeElement typeElement, List<VariableElement> injectFields) {
+  public InteractorAnnotatedClass(
+      TypeElement typeElement, List<? extends VariableElement> dependencies, boolean isBasic) {
     super(typeElement);
-    this.injectFields = injectFields;
+    this.dependencies = dependencies;
+    this.isBasic = isBasic;
   }
 
-  /** @return the list of injected fields */
-  public List<VariableElement> getInjectFields() {
-    return injectFields;
+  /** @return the list of dependencies. */
+  public List<? extends VariableElement> getDependencies() {
+    return dependencies;
   }
 
   /** {@inheritDoc} */
   @Override
   public String getNameSuffix() {
     return Constants.INTERACTOR_SUFFIX;
+  }
+
+  /** @return Whether this interactor extends BasicInteractor. */
+  public boolean isBasic() {
+    return isBasic;
   }
 }

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/ProcessorPipeline.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/ProcessorPipeline.java
@@ -17,7 +17,6 @@ package com.uber.rib.compiler;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
-
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/RibInteractorProcessorPipeline.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/RibInteractorProcessorPipeline.java
@@ -16,14 +16,11 @@
 package com.uber.rib.compiler;
 
 import androidx.annotation.Nullable;
-
 import com.uber.rib.core.RibInteractor;
-
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.lang.model.element.TypeElement;
 
 /** The processor pipeline for {@link RibInteractor} */

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/RibProcessor.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/RibProcessor.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;

--- a/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/TypeProcessorPipeline.java
+++ b/android/libraries/rib-compiler-app/src/main/java/com/uber/rib/compiler/TypeProcessorPipeline.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;

--- a/android/libraries/rib-compiler-app/src/test/java/com/uber/rib/compiler/InteractorAnnotationVerifierTest.java
+++ b/android/libraries/rib-compiler-app/src/test/java/com/uber/rib/compiler/InteractorAnnotationVerifierTest.java
@@ -15,24 +15,17 @@
  */
 package com.uber.rib.compiler;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+
+import org.junit.Test;
 
 public class InteractorAnnotationVerifierTest extends InteractorProcessorTestBase {
 
   @Test
-  @Ignore
   public void verify_whenTypeElementIsValid_shouldCompile() {
     addResourceToSources("fixtures/AnnotatedInteractor.java");
-    assert_()
-        .about(javaSources())
-        .that(getSources())
-        .withCompilerOptions("-source", "1.7", "-target", "1.7")
-        .processedWith(getRibProcessor())
-        .compilesWithoutError();
+    assertCompiles();
   }
 
   @Test
@@ -42,13 +35,13 @@ public class InteractorAnnotationVerifierTest extends InteractorProcessorTestBas
   }
 
   @Test
-  public void verify_whenBuilderHasAConstructor_shouldWriteErrorMessage() {
+  public void verify_whenInteractorHasAConstructor_shouldCompile() {
     addResourceToSources("fixtures/CustomConstructorInteractor.java");
-    assertFailsWithError("");
+    assertCompiles();
   }
 
   @Test
-  public void verify_whenTypeElementIsNotBuilder_shouldWriteErrorMessage() {
+  public void verify_whenTypeElementIsNotInteractor_shouldWriteErrorMessage() {
     addResourceToSources("fixtures/AnnotatedNonInteractor.java");
     assertFailsWithError(
         "test.AnnotatedNonInteractor is annotated with @RibInteractor but is not an Interactor subclass");
@@ -62,5 +55,14 @@ public class InteractorAnnotationVerifierTest extends InteractorProcessorTestBas
         .processedWith(getRibProcessor())
         .failsToCompile()
         .withErrorContaining(expectedErrorMessage);
+  }
+
+  private void assertCompiles() {
+    assert_()
+        .about(javaSources())
+        .that(getSources())
+        .withCompilerOptions("-source", "1.7", "-target", "1.7")
+        .processedWith(getRibProcessor())
+        .compilesWithoutError();
   }
 }

--- a/android/libraries/rib-compiler-app/src/test/java/com/uber/rib/compiler/InteractorProcessorTestBase.java
+++ b/android/libraries/rib-compiler-app/src/test/java/com/uber/rib/compiler/InteractorProcessorTestBase.java
@@ -17,15 +17,12 @@ package com.uber.rib.compiler;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Before;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.tools.JavaFileObject;
+import org.junit.Before;
 
 public abstract class InteractorProcessorTestBase {
 
@@ -38,7 +35,7 @@ public abstract class InteractorProcessorTestBase {
         new RibProcessor() {
           @Override
           protected List<ProcessorPipeline> getProcessorPipelines(ProcessContext processContext) {
-            return Collections.<ProcessorPipeline>singletonList(
+            return Collections.singletonList(
                 new RibInteractorProcessorPipeline(processContext, null));
           }
 

--- a/android/libraries/rib-compiler-app/src/test/resources/fixtures/AnnotatedNonInteractor.java
+++ b/android/libraries/rib-compiler-app/src/test/resources/fixtures/AnnotatedNonInteractor.java
@@ -18,4 +18,6 @@ package test;
 import com.uber.rib.core.RibInteractor;
 
 @RibInteractor
-public class AnnotatedNonInteractor { }
+public class AnnotatedNonInteractor {
+
+}

--- a/android/libraries/rib-compiler-test/build.gradle
+++ b/android/libraries/rib-compiler-test/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 /*
  * Copyright (C) 2017. Uber Technologies
  *
@@ -26,6 +28,9 @@ dependencies {
 
     testCompile deps.androidx.annotations
     testCompile deps.test.compileTesting
+    if (!Jvm.current().javaVersion.isJava9Compatible()) {
+        testCompile files(Jvm.current().getToolsJar())
+    }
 }
 
 // https://code.google.com/p/android/issues/detail?id=64887

--- a/android/libraries/rib-compiler-test/src/main/java/com/uber/rib/compiler/RibTestProcessor.java
+++ b/android/libraries/rib-compiler-test/src/main/java/com/uber/rib/compiler/RibTestProcessor.java
@@ -18,10 +18,8 @@ package com.uber.rib.compiler;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import java.util.List;
 import java.util.Set;
-
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 

--- a/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorProcessorTestBase.java
+++ b/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorProcessorTestBase.java
@@ -16,19 +16,15 @@
 package com.uber.rib.compiler;
 
 import androidx.annotation.NonNull;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Before;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.JavaFileObject;
+import org.junit.Before;
 
 public abstract class InteractorTestGeneratorProcessorTestBase {
 

--- a/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorTest.java
+++ b/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorTest.java
@@ -15,22 +15,38 @@
  */
 package com.uber.rib.compiler;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
+import javax.tools.JavaFileObject;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
 public class InteractorTestGeneratorTest extends InteractorTestGeneratorProcessorTestBase {
 
-  @Ignore("The maven coordinate com.sun:tools no longer appears to work. So this test won't pass.")
   @Test
-  public void processor_withAnInteractor_shouldCreateANewScopeAnnotation() {
+  public void processor_withAnInteractor_shouldGenerateTestHelper() {
     JavaFileObject expectedTestCreator = getResourceFile("fixtures/TestAnnotatedInteractor.java");
 
     addResourceToSources("fixtures/AnnotatedInteractor.java");
+    assert_()
+        .about(javaSources())
+        .that(getSources())
+        .withCompilerOptions("-source", "1.7", "-target", "1.7")
+        .processedWith(getRibInteractorProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedTestCreator);
+  }
+
+  @Ignore("Unignore once BasicInteractor is added to rib-base")
+  @Test
+  public void processor_withABasicInteractor_shouldGenerateTestHelper() {
+    JavaFileObject expectedTestCreator =
+        getResourceFile("fixtures/TestAnnotatedBasicInteractor.java");
+
+    addResourceToSources("fixtures/AnnotatedBasicInteractor.java");
     assert_()
         .about(javaSources())
         .that(getSources())


### PR DESCRIPTION
This PR aligns the `rib-compiler-app` & `rib-compiler-test` modules with our internal versions as part of #392. The changes consist of:
- one behavior change in allowing `Interactor`s to have constructors when not injecting fields (adds [Motif](https://github.com/uber/motif) support)
- updated tests to account for new behavior
- reordering of imports
- whitespace 