### PR TITLE
Decouple base RIB classes from Dagger

### DIFF
--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/BasicViewRouter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/BasicViewRouter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+import android.view.View;
+
+/**
+ * {@link ViewRouter} that does not require an {@link InteractorBaseComponent}.
+ *
+ * @param <I> type of interactor.
+ */
+public abstract class BasicViewRouter<V extends View, I extends Interactor>
+    extends ViewRouter<V, I, InteractorBaseComponent> {
+
+  public BasicViewRouter(V view, I interactor) {
+    super(view, interactor);
+  }
+}

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
@@ -35,6 +35,11 @@ public abstract class ViewRouter<
     this.view = view;
   }
 
+  protected ViewRouter(V view, I interactor) {
+    super(null, interactor, com.uber.rib.core.RibRefWatcher.getInstance(), getMainThread());
+    this.view = view;
+  }
+
   /** @return the router's view. */
   public V getView() {
     return view;

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/BasicInteractor.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/BasicInteractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+/**
+ * {@link Interactor} that doesn't rely on field injection.
+ *
+ * @param <P> the type of {@link Presenter}.
+ * @param <R> the type of {@link Router}.
+ */
+public abstract class BasicInteractor<P, R extends Router> extends Interactor<P, R> {
+
+  @SuppressWarnings("HidingField")
+  protected P presenter;
+
+  protected BasicInteractor(P presenter) {
+    super(presenter);
+    this.presenter = presenter;
+  }
+}

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/BasicRouter.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/BasicRouter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+/**
+ * {@link Router} that does not require an {@link InteractorBaseComponent}.
+ *
+ * @param <I> type of interactor.
+ */
+public abstract class BasicRouter<I extends Interactor> extends Router<I, InteractorBaseComponent> {
+
+  public BasicRouter(I interactor) {
+    super(interactor);
+  }
+}

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
@@ -49,17 +49,35 @@ public class Router<I extends com.uber.rib.core.Interactor, C extends Interactor
 
   private boolean isLoaded;
 
-  public Router(I interactor, C component) {
+  protected Router(I interactor, @Nullable C component) {
     this(component, interactor, com.uber.rib.core.RibRefWatcher.getInstance(), getMainThread());
   }
 
-  @SuppressWarnings("unchecked")
-  Router(
-      C component, I interactor, com.uber.rib.core.RibRefWatcher ribRefWatcher, Thread mainThread) {
+  protected Router(I interactor) {
+    this(null, interactor, com.uber.rib.core.RibRefWatcher.getInstance(), getMainThread());
+  }
+
+  protected Router(
+      @Nullable C component,
+      I interactor,
+      com.uber.rib.core.RibRefWatcher ribRefWatcher,
+      Thread mainThread) {
     this.interactor = interactor;
     this.ribRefWatcher = ribRefWatcher;
     this.mainThread = mainThread;
-    component.inject(interactor);
+    inject(component);
+    attachToInteractor();
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void inject(@Nullable C component) {
+    if (component != null) {
+      component.inject(interactor);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void attachToInteractor() {
     interactor.setRouter(this);
   }
 
@@ -241,7 +259,7 @@ public class Router<I extends com.uber.rib.core.Interactor, C extends Interactor
     }
   }
 
-  private static Thread getMainThread() {
+  static Thread getMainThread() {
     try {
       return Looper.getMainLooper().getThread();
     } catch (Exception e) {

--- a/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorTest.java
+++ b/android/libraries/rib-compiler-test/src/test/java/com/uber/rib/compiler/InteractorTestGeneratorTest.java
@@ -19,8 +19,6 @@ import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
 import javax.tools.JavaFileObject;
-
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class InteractorTestGeneratorTest extends InteractorTestGeneratorProcessorTestBase {
@@ -40,7 +38,6 @@ public class InteractorTestGeneratorTest extends InteractorTestGeneratorProcesso
         .generatesSources(expectedTestCreator);
   }
 
-  @Ignore("Unignore once BasicInteractor is added to rib-base")
   @Test
   public void processor_withABasicInteractor_shouldGenerateTestHelper() {
     JavaFileObject expectedTestCreator =

--- a/android/libraries/rib-compiler-test/src/test/resources/fixtures/AnnotatedBasicInteractor.java
+++ b/android/libraries/rib-compiler-test/src/test/resources/fixtures/AnnotatedBasicInteractor.java
@@ -1,0 +1,21 @@
+package fixtures;
+
+import com.uber.rib.core.BasicInteractor;
+import com.uber.rib.core.Presenter;
+import com.uber.rib.core.RibInteractor;
+import com.uber.rib.core.Router;
+
+import javax.inject.Inject;
+
+@RibInteractor
+public class AnnotatedBasicInteractor extends BasicInteractor<Presenter, Router> {
+
+    private final Boolean fieldOne;
+    private final Integer fieldTwo;
+
+    public AnnotatedBasicInteractor(Presenter presenter, Boolean fieldOne, Integer fieldTwo) {
+        super(presenter);
+        this.fieldOne = fieldOne;
+        this.fieldTwo = fieldTwo;
+    }
+}

--- a/android/libraries/rib-compiler-test/src/test/resources/fixtures/TestAnnotatedBasicInteractor.java
+++ b/android/libraries/rib-compiler-test/src/test/resources/fixtures/TestAnnotatedBasicInteractor.java
@@ -1,0 +1,15 @@
+package fixtures;
+
+import com.uber.rib.core.Presenter;
+import java.lang.Boolean;
+import java.lang.Integer;
+
+public class TestAnnotatedBasicInteractor {
+    private TestAnnotatedBasicInteractor() {
+    }
+
+    public static AnnotatedBasicInteractor create(final Presenter presenter, final Boolean fieldOne,
+          final Integer fieldTwo) {
+        return new AnnotatedBasicInteractor(presenter, fieldOne, fieldTwo);
+    }
+}

--- a/android/libraries/rib-compiler-test/src/test/resources/fixtures/TestForcedBasicInteractor.java
+++ b/android/libraries/rib-compiler-test/src/test/resources/fixtures/TestForcedBasicInteractor.java
@@ -1,0 +1,15 @@
+package fixtures;
+
+import com.uber.rib.core.Presenter;
+import java.lang.Boolean;
+import java.lang.Integer;
+
+public class TestForcedBasicInteractor {
+    private TestForcedBasicInteractor() {
+    }
+
+    public static ForcedBasicInteractor create(final Presenter presenter, final Boolean fieldOne,
+          final Integer fieldTwo) {
+        return new ForcedBasicInteractor(presenter, fieldOne, fieldTwo);
+    }
+}


### PR DESCRIPTION
Motif RIBs don't have a Component. Today, Routers expect a InteractorBaseComponent type parameter which a Motif RIB would not be able to provide. In order to reduce the surface area of this change, we'll instead introduce a new class BasicRouter that does not require a Component. We achieve this by updating the base class to allow null components. We also are adding a new BasicInteractor class that supports constructor injection.