### PR TITLE
Add fakes for RIB classes

### DIFF
--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     testCompile deps.test.junit
     testCompile deps.test.mockito
     testCompile deps.test.truth
+    testCompile(project(":libraries:rib-test")) {
+        transitive = false
+    }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/Presenter.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/Presenter.java
@@ -27,11 +27,13 @@ import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
-/** Contains presentation logic. This class exists mainly for legacy reasons. In the past
- * we believed it was useful to have a class between interactors and views to facilitate model
- * transformations and believed these transformations would be complex enough to require its own
- * lifecycle. In practice this caused confusion: if both a presenter and interactor can perform
- * complex rx logic it becomes unclear where you should write your bussiness logic. */
+/**
+ * Contains presentation logic. This class exists mainly for legacy reasons. In the past we believed
+ * it was useful to have a class between interactors and views to facilitate model transformations
+ * and believed these transformations would be complex enough to require its own lifecycle. In
+ * practice this caused confusion: if both a presenter and interactor can perform complex rx logic
+ * it becomes unclear where you should write your bussiness logic.
+ */
 public abstract class Presenter implements ScopeProvider {
 
   private final BehaviorRelay<PresenterEvent> behaviorRelay = BehaviorRelay.create();

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @param <I> type of interactor this router routes.
  */
-public class Router<I extends Interactor> {
+public abstract class Router<I extends Interactor> {
 
   @VisibleForTesting static final String KEY_CHILD_ROUTERS = "Router.childRouters";
   @VisibleForTesting static final String KEY_INTERACTOR = "Router.interactor";

--- a/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
+++ b/android/libraries/rib-base/src/main/java/com/uber/rib/core/Router.java
@@ -176,8 +176,7 @@ public abstract class Router<I extends Interactor> {
     ribRefWatcher.logBreadcrumb(
         "DETACHED", childRouter.getClass().getSimpleName(), this.getClass().getSimpleName());
     if (savedInstanceState != null) {
-      Bundle childrenBundles =
-          checkNotNull(savedInstanceState.getBundleExtra(KEY_CHILD_ROUTERS));
+      Bundle childrenBundles = checkNotNull(savedInstanceState.getBundleExtra(KEY_CHILD_ROUTERS));
       childrenBundles.putBundleExtra(childRouter.tag, null);
     }
 

--- a/android/libraries/rib-base/src/test/java/com/uber/rib/core/InteractorAndRouterTest.java
+++ b/android/libraries/rib-base/src/test/java/com/uber/rib/core/InteractorAndRouterTest.java
@@ -242,13 +242,8 @@ public class InteractorAndRouterTest {
     @Override
     protected void didBecomeActive(@Nullable Bundle savedInstanceState) {
       super.didBecomeActive(savedInstanceState);
-
-      com.uber.rib.core.Router router =
-          new Router<>(
-              mock(InteractorComponent.class),
-              mChildInteractor,
-              RibRefWatcher.getInstance(),
-              Thread.currentThread());
+      Router router =
+          new FakeRouter<>(mChildInteractor, RibRefWatcher.getInstance(), Thread.currentThread());
       getRouter().attachChild(router);
     }
 

--- a/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeComponent.java
+++ b/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeComponent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+public final class FakeComponent<P extends Presenter, T extends Interactor<P, ?>>
+    implements InteractorComponent<P, T> {
+
+  public static <T extends Interactor<FakePresenter, ?>>
+      FakeComponent<FakePresenter, T> withFakePresenterFor(Class<T> interactorClass) {
+    return new FakeComponent<>(new FakePresenter());
+  }
+
+  private P presenter;
+
+  private FakeComponent(P presenter) {
+    this.presenter = presenter;
+  }
+
+  @Override
+  public void inject(T interactor) {}
+
+  @Override
+  public P presenter() {
+    return presenter;
+  }
+}

--- a/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeInteractor.java
+++ b/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeInteractor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+@SuppressWarnings("RibInteractorOnIteractor")
+public class FakeInteractor<P, R extends Router> extends Interactor<P, R> {
+
+  @SuppressWarnings("unchecked")
+  public void attach() {
+    this.presenter = (P) new FakePresenter();
+    setRouter((R) new FakeRouter(this));
+    dispatchAttach(null);
+  }
+
+  public void detach() {
+    dispatchDetach();
+  }
+}

--- a/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakePresenter.java
+++ b/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakePresenter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+public final class FakePresenter extends Presenter {}

--- a/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeRouter.java
+++ b/android/libraries/rib-test/src/main/java/com/uber/rib/core/FakeRouter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+/**
+ * Router for testing that does not automatically attach to the interactor.
+ *
+ * @param <I>
+ */
+public final class FakeRouter<I extends Interactor<?, Router>> extends Router<I> {
+
+  public FakeRouter(I interactor) {
+    super(interactor);
+  }
+
+  public FakeRouter(I interactor, RibRefWatcher ribRefWatcher, Thread mainThread) {
+    super(null, interactor, ribRefWatcher, mainThread);
+  }
+
+  @Override
+  protected void attachToInteractor() {
+    // do not automatically attach this
+  }
+}


### PR DESCRIPTION
Router does not need to be concrete and was only such because iOS does not have abstract classes. Create fakes for easier testing without mocks. #392 