### PR TITLE
Align rib-android with internal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ jobs:
         components:
           - tools                             # Tools
           - platform-tools                    # Platform tools
-          - build-tools-28.0.3                # Build tools version
+          - build-tools-30.0.2                # Build tools version
           - android-28                        # Target SDK version
+          - android-30                        # Compile SDK version
           - extra-android-m2repository        # Support repo
           - sys-img-armeabi-v7a-android-18    # Emulator
 
       jdk: oraclejdk8
+
+      before_install:
+        - yes | sdkmanager "platforms;android-28"
+        - yes | sdkmanager "platforms;android-30"
+        - yes | sdkmanager "build-tools;30.0.2"
 
       script:
         - cd android

--- a/android/demos/memory-leaks/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/demos/memory-leaks/src/main/java/com/uber/rib/RootActivity.java
@@ -29,7 +29,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {});
     return rootBuilder.build(parentViewGroup);
   }

--- a/android/demos/memory-leaks/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/demos/memory-leaks/src/main/java/com/uber/rib/root/RootRouter.java
@@ -26,7 +26,7 @@ import com.uber.rib.root.logged_out.LoggedOutRouter;
 /**
  * Adds and removes children of {@link RootBuilder.RootScope}.
  */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   private final LoggedOutBuilder loggedOutBuilder;
   private final LoggedInBuilder loggedInBuilder;

--- a/android/demos/memory-leaks/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
+++ b/android/demos/memory-leaks/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link LoggedOutBuilder.LoggedOutScope}.
  */
 public class LoggedOutRouter extends
-    ViewRouter<LoggedOutView, LoggedOutInteractor, LoggedOutBuilder.Component> {
+    ViewRouter<LoggedOutView, LoggedOutInteractor> {
 
   public LoggedOutRouter(
       LoggedOutView view,

--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -44,8 +44,8 @@ def apt = [
 ]
 
 def build = [
-    buildToolsVersion: '28.0.3',
-    compileSdkVersion: 28,
+    buildToolsVersion: '30.0.2',
+    compileSdkVersion: 30,
     gradlePluginsUrl : "https://plugins.gradle.org/m2/",
     ci: 'true' == System.getenv('CI'),
     minSdkVersion: 16,

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/ActivityStarter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/ActivityStarter.java
@@ -33,9 +33,11 @@ public interface ActivityStarter {
   /**
    * Start an activity with the given intent, to be notified when that activity finishes.
    *
+   * @deprecated use plain Activity instead
    * @param intent The intent to open a new activity.
    * @param requestCode The code unique to your current activity to know which activity result is
    *     from this request.
    */
+  @Deprecated
   void startActivityForResult(Intent intent, int requestCode);
 }

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/BasicViewRouter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/BasicViewRouter.java
@@ -23,7 +23,7 @@ import android.view.View;
  * @param <I> type of interactor.
  */
 public abstract class BasicViewRouter<V extends View, I extends Interactor>
-    extends ViewRouter<V, I, InteractorBaseComponent> {
+    extends ViewRouter<V, I> {
 
   public BasicViewRouter(V view, I interactor) {
     super(view, interactor);

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibActivity.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibActivity.java
@@ -16,10 +16,11 @@
 package com.uber.rib.core;
 
 import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.view.ViewGroup;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
-import android.view.ViewGroup;
-
 import com.google.common.base.Preconditions;
 import com.jakewharton.rxrelay2.BehaviorRelay;
 import com.jakewharton.rxrelay2.PublishRelay;
@@ -33,8 +34,6 @@ import com.uber.rib.core.lifecycle.ActivityLifecycleEvent;
 
 import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
-import io.reactivex.functions.Function;
-import io.reactivex.functions.Predicate;
 import androidx.appcompat.app.AppCompatActivity;
 
 /** Base implementation for all VIP {@link android.app.Activity}s. */
@@ -53,6 +52,8 @@ public abstract class RibActivity extends AppCompatActivity
             return ActivityLifecycleEvent.create(ActivityLifecycleEvent.Type.STOP);
           case RESUME:
             return ActivityLifecycleEvent.create(ActivityLifecycleEvent.Type.PAUSE);
+          case USER_LEAVING:
+            return ActivityLifecycleEvent.create(ActivityLifecycleEvent.Type.DESTROY);
           case PAUSE:
             return ActivityLifecycleEvent.create(ActivityLifecycleEvent.Type.STOP);
           case STOP:
@@ -79,44 +80,10 @@ public abstract class RibActivity extends AppCompatActivity
     return lifecycleRelay.hide();
   }
 
-  /**
-   * @param <T> The type of {@link ActivityLifecycleEvent} subclass you want.
-   * @param clazz The {@link ActivityLifecycleEvent} subclass you want.
-   * @return an observable of this activity's lifecycle events.
-   */
-  public <T extends ActivityLifecycleEvent> Observable<T> lifecycle(final Class<T> clazz) {
-    return lifecycle()
-        .filter(
-            new Predicate<ActivityLifecycleEvent>() {
-              @Override
-              public boolean test(ActivityLifecycleEvent activityEvent) throws Exception {
-                return clazz.isAssignableFrom(activityEvent.getClass());
-              }
-            })
-        .cast(clazz);
-  }
-
   /** @return an observable of this activity's lifecycle events. */
   @Override
   public Observable<ActivityCallbackEvent> callbacks() {
     return callbacksRelay.hide();
-  }
-
-  /**
-   * @param <T> The type of {@link ActivityCallbackEvent} subclass you want.
-   * @param clazz The {@link ActivityCallbackEvent} subclass you want.
-   * @return an observable of this activity's callbacks events.
-   */
-  public <T extends ActivityCallbackEvent> Observable<T> callbacks(final Class<T> clazz) {
-    return callbacks()
-        .filter(
-            new Predicate<ActivityCallbackEvent>() {
-              @Override
-              public boolean test(ActivityCallbackEvent activityCallbackEvent) throws Exception {
-                return clazz.isAssignableFrom(activityCallbackEvent.getClass());
-              }
-            })
-        .cast(clazz);
   }
 
   @Override
@@ -142,7 +109,7 @@ public abstract class RibActivity extends AppCompatActivity
   protected void onCreate(@Nullable android.os.Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    ViewGroup rootViewGroup = ((ViewGroup) findViewById(android.R.id.content));
+    ViewGroup rootViewGroup = findViewById(android.R.id.content);
 
     lifecycleRelay.accept(ActivityLifecycleEvent.createOnCreateEvent(savedInstanceState));
     router = createRouter(rootViewGroup);
@@ -154,6 +121,7 @@ public abstract class RibActivity extends AppCompatActivity
     router.dispatchAttach(wrappedBundle);
 
     rootViewGroup.addView(router.getView());
+    RibEvents.getInstance().emitEvent(RibEventType.ATTACHED, router, null);
   }
 
   @Override
@@ -181,7 +149,15 @@ public abstract class RibActivity extends AppCompatActivity
 
   @Override
   @CallSuper
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+
+    callbacksRelay.accept(ActivityCallbackEvent.createNewIntent(intent));
+  }
+
+  @Override
+  @CallSuper
+  protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
 
     callbacksRelay.accept(
@@ -212,6 +188,7 @@ public abstract class RibActivity extends AppCompatActivity
     }
     if (router != null) {
       router.dispatchDetach();
+      RibEvents.getInstance().emitEvent(RibEventType.DETACHED, router, null);
     }
     router = null;
     super.onDestroy();
@@ -225,11 +202,46 @@ public abstract class RibActivity extends AppCompatActivity
   }
 
   @Override
+  @CallSuper
+  public void onTrimMemory(int level) {
+    super.onTrimMemory(level);
+    callbacksRelay.accept(ActivityCallbackEvent.createTrimMemoryEvent(level));
+  }
+
+  @Override
+  public void onPictureInPictureModeChanged(
+      boolean isInPictureInPictureMode, Configuration newConfig) {
+    callbacksRelay.accept(
+        ActivityCallbackEvent.createPictureInPictureMode(isInPictureInPictureMode));
+  }
+
+  @Override
   public void onBackPressed() {
     if (router != null && !router.handleBackPress()) {
-      super.onBackPressed();
+      onUnhandledBackPressed();
+
+      // https://issuetracker.google.com/issues/139738913
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+          && isTaskRoot()
+          && getSupportFragmentManager().getBackStackEntryCount() == 0) {
+        super.finishAfterTransition();
+      } else {
+        super.onBackPressed();
+      }
     }
   }
+
+  @Override
+  protected void onUserLeaveHint() {
+    lifecycleRelay.accept(ActivityLifecycleEvent.create(ActivityLifecycleEvent.Type.USER_LEAVING));
+    super.onUserLeaveHint();
+  }
+
+  /**
+   * Invoked when none of the ribs handle back press. In this case, default activity back press
+   * behavior occurs.
+   */
+  protected void onUnhandledBackPressed() {}
 
   /**
    * @return the {@link Interactor} when the activity has alive.
@@ -249,5 +261,5 @@ public abstract class RibActivity extends AppCompatActivity
    *
    * @return the {@link Interactor}.
    */
-  protected abstract ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup);
+  protected abstract ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup);
 }

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibActivity.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibActivity.java
@@ -64,8 +64,7 @@ public abstract class RibActivity extends AppCompatActivity
         throw new UnsupportedOperationException("Binding to " + lastEvent + " not yet implemented");
       };
 
-  @SuppressWarnings("NullableProblems")
-  private ViewRouter<?, ?, ?> router;
+  private ViewRouter<?, ?> router;
 
   private final BehaviorRelay<ActivityLifecycleEvent> lifecycleBehaviorRelay =
       BehaviorRelay.create();

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibDebugOverlay.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/RibDebugOverlay.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.drawable.Drawable;
+
+public class RibDebugOverlay extends Drawable {
+
+  private static final int OVERLAY_COLOR = Color.RED;
+  private static final int OVERLAY_ALPHA = 35;
+  private boolean enabled = true;
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  @Override
+  public void draw(Canvas canvas) {
+    if (enabled) {
+      Paint p = new Paint();
+      p.setColor(OVERLAY_COLOR);
+      p.setAlpha(OVERLAY_ALPHA);
+      p.setStyle(Paint.Style.FILL);
+      canvas.drawPaint(p);
+    }
+  }
+
+  @Override
+  public void setAlpha(int i) {}
+
+  @SuppressWarnings("NullAway")
+  @Override
+  public void setColorFilter(ColorFilter colorFilter) {}
+
+  @Override
+  public int getOpacity() {
+    return PixelFormat.TRANSLUCENT;
+  }
+}

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/RxActivityEvents.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/RxActivityEvents.java
@@ -18,6 +18,7 @@ package com.uber.rib.core;
 import com.uber.rib.core.lifecycle.ActivityCallbackEvent;
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent;
 import io.reactivex.Observable;
+import io.reactivex.functions.Predicate;
 
 /** Interface for reactive activities. */
 public interface RxActivityEvents {
@@ -27,4 +28,40 @@ public interface RxActivityEvents {
 
   /** @return an observable of this activity's lifecycle events. */
   Observable<ActivityCallbackEvent> callbacks();
+
+  /**
+   * @param <T> The type of {@link ActivityLifecycleEvent} subclass you want.
+   * @param clazz The {@link ActivityLifecycleEvent} subclass you want.
+   * @return an observable of this activity's lifecycle events.
+   */
+  default <T extends ActivityLifecycleEvent> Observable<T> lifecycle(final Class<T> clazz) {
+    return lifecycle()
+        // Lambdas within interfaces are not yet supported.
+        .filter(
+            new Predicate<ActivityLifecycleEvent>() {
+              @Override
+              public boolean test(final ActivityLifecycleEvent activityEvent) {
+                return clazz.isAssignableFrom(activityEvent.getClass());
+              }
+            })
+        .cast(clazz);
+  }
+
+  /**
+   * @param <T> The type of {@link ActivityCallbackEvent} subclass you want.
+   * @param clazz The {@link ActivityCallbackEvent} subclass you want.
+   * @return an observable of this activity's callbacks events.
+   */
+  default <T extends ActivityCallbackEvent> Observable<T> callbacks(final Class<T> clazz) {
+    return callbacks()
+        // Lambdas within interfaces are not yet supported.
+        .filter(
+            new Predicate<ActivityCallbackEvent>() {
+              @Override
+              public boolean test(final ActivityCallbackEvent activityEvent) {
+                return clazz.isAssignableFrom(activityEvent.getClass());
+              }
+            })
+        .cast(clazz);
+  }
 }

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewBuilder.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewBuilder.java
@@ -42,14 +42,8 @@ public abstract class ViewBuilder<ViewType extends View, RouterT extends Router,
    */
   protected final ViewType createView(ViewGroup parentViewGroup) {
     final Context context = parentViewGroup.getContext();
-    final ViewType view =
-        inflateView(LayoutInflater.from(onThemeContext(context)), parentViewGroup);
 
-    if (XRay.isEnabled()) {
-      XRay.apply(this, view);
-    }
-
-    return view;
+    return inflateView(LayoutInflater.from(onThemeContext(context)), parentViewGroup);
   }
 
   /**

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
@@ -22,15 +22,12 @@ import android.view.View;
  *
  * @param <V> type of view owned by the router.
  * @param <I> type of interactor owned by the router.
- * @param <C> type of dependency owned by the router.
  */
-public abstract class ViewRouter<
-        V extends View, I extends Interactor, C extends InteractorBaseComponent>
-    extends Router<I> {
+public abstract class ViewRouter<V extends View, I extends Interactor> extends Router<I> {
 
   private final V view;
 
-  public ViewRouter(V view, I interactor, C component) {
+  public ViewRouter(V view, I interactor, InteractorBaseComponent component) {
     super(interactor, component);
     this.view = view;
   }

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/ViewRouter.java
@@ -30,11 +30,17 @@ public abstract class ViewRouter<V extends View, I extends Interactor> extends R
   public ViewRouter(V view, I interactor, InteractorBaseComponent component) {
     super(interactor, component);
     this.view = view;
+    if (XRay.isEnabled()) {
+      XRay.apply(this, view);
+    }
   }
 
   protected ViewRouter(V view, I interactor) {
     super(null, interactor, com.uber.rib.core.RibRefWatcher.getInstance(), getMainThread());
     this.view = view;
+    if (XRay.isEnabled()) {
+      XRay.apply(this, view);
+    }
   }
 
   /** @return the router's view. */

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/XRay.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/XRay.java
@@ -23,6 +23,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 import android.view.View;
+import androidx.annotation.Nullable;
 
 /** Utility class that shows riblets name in its background. */
 public final class XRay {
@@ -37,14 +38,10 @@ public final class XRay {
 
   private boolean isEnabled;
 
-  private final Paint textPaint;
+  @Nullable private Paint textPaint;
 
   private XRay() {
     isEnabled = false;
-
-    textPaint = new Paint();
-    textPaint.setTextSize(TEXT_SIZE);
-    textPaint.setColor(TEXT_COLOR);
   }
 
   /** Toggles state of XRay. */
@@ -60,10 +57,10 @@ public final class XRay {
   /**
    * Puts {@link ViewBuilder}s riblet name in the background of the {@link View}
    *
-   * @param viewBuilder a {@link ViewBuilder} which riblets name should be written.
+   * @param viewRouter a {@link ViewRouter} which riblets name should be written.
    * @param view a {@link View} to put the name behind.
    */
-  static void apply(final ViewBuilder viewBuilder, final View view) {
+  static void apply(final ViewRouter viewRouter, final View view) {
     final Drawable oldBackground = view.getBackground();
 
     final Bitmap bitmap;
@@ -74,7 +71,7 @@ public final class XRay {
       bitmap = Bitmap.createBitmap(FRAME_WIDTH, FRAME_HEIGHT, Bitmap.Config.ARGB_8888);
     }
 
-    INSTANCE.writeOnBitmap(bitmap, getRibletName(viewBuilder));
+    INSTANCE.writeOnBitmap(bitmap, getRibletName(viewRouter));
 
     final BitmapDrawable newBackground =
         new BitmapDrawable(view.getContext().getResources(), bitmap);
@@ -106,16 +103,26 @@ public final class XRay {
     return bitmap;
   }
 
-  private static String getRibletName(final ViewBuilder viewBuilder) {
-    return viewBuilder.getClass().getSimpleName().replace("Builder", "");
+  private static String getRibletName(final ViewRouter viewRouter) {
+    return viewRouter.getClass().getSimpleName().replace("Router", "");
   }
 
   private void writeOnBitmap(final Bitmap bitmap, final String text) {
     final Canvas canvas = new Canvas(bitmap);
+    final Paint textPaint = getTextPaint();
 
     final float xStartPoint = (bitmap.getWidth() - textPaint.measureText(text)) / 2f;
     final float yStartPoint = bitmap.getHeight() / 2f;
 
     canvas.drawText(text, xStartPoint, yStartPoint, textPaint);
+  }
+
+  private Paint getTextPaint() {
+    if (textPaint == null) {
+      textPaint = new Paint();
+      textPaint.setTextSize(TEXT_SIZE);
+      textPaint.setColor(TEXT_COLOR);
+    }
+    return textPaint;
   }
 }

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/lifecycle/ActivityCallbackEvent.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/lifecycle/ActivityCallbackEvent.java
@@ -19,7 +19,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
-
 import java.util.Locale;
 
 /** Callback events that can be emitted by Activities. */
@@ -75,6 +74,30 @@ public class ActivityCallbackEvent implements ActivityEvent {
     return new ActivityCallbackEvent.SaveInstanceState(outState);
   }
 
+  /**
+   * Creates an event for {@link Activity#onTrimMemory(int)}
+   *
+   * @param trimMemoryType that is passed by the activity callback
+   * @return the created {@link TrimMemory}
+   */
+  public static TrimMemory createTrimMemoryEvent(int trimMemoryType) {
+    return new TrimMemory(trimMemoryType);
+  }
+
+  public static PictureInPictureMode createPictureInPictureMode(boolean isInPictureInPictureMode) {
+    return new PictureInPictureMode(isInPictureInPictureMode);
+  }
+
+  /**
+   * Creates an event for onNewIntent.
+   *
+   * @param intent is the new intent received
+   * @return the created {@link NewIntent}.
+   */
+  public static NewIntent createNewIntent(Intent intent) {
+    return new NewIntent(intent);
+  }
+
   /** @return this event's type. */
   @Override
   public Type getType() {
@@ -89,7 +112,54 @@ public class ActivityCallbackEvent implements ActivityEvent {
   public enum Type implements BaseType {
     LOW_MEMORY,
     ACTIVITY_RESULT,
-    SAVE_INSTANCE_STATE
+    SAVE_INSTANCE_STATE,
+    TRIM_MEMORY,
+    PICTURE_IN_PICTURE_MODE,
+    NEW_INTENT
+  }
+
+  /** An {@link ActivityCallbackEvent} that represents {@link Activity#onNewIntent(Intent)} event */
+  public static class NewIntent extends ActivityCallbackEvent {
+
+    private final Intent intent;
+
+    private NewIntent(Intent intent) {
+      super(Type.NEW_INTENT);
+      this.intent = intent;
+    }
+
+    public Intent getIntent() {
+      return intent;
+    }
+  }
+
+  public static class PictureInPictureMode extends ActivityCallbackEvent {
+
+    private final boolean isInPictureInPictureMode;
+
+    private PictureInPictureMode(boolean isInPictureInPictureMode) {
+      super(Type.PICTURE_IN_PICTURE_MODE);
+      this.isInPictureInPictureMode = isInPictureInPictureMode;
+    }
+
+    public boolean isInPictureInPictureMode() {
+      return isInPictureInPictureMode;
+    }
+  }
+
+  /** An {@link ActivityCallbackEvent} that represents {@link Activity#onTrimMemory(int)} event */
+  public static class TrimMemory extends ActivityCallbackEvent {
+
+    private final int trimMemoryType;
+
+    TrimMemory(int trimMemoryType) {
+      super(Type.TRIM_MEMORY);
+      this.trimMemoryType = trimMemoryType;
+    }
+
+    public int getTrimMemoryType() {
+      return trimMemoryType;
+    }
   }
 
   /**

--- a/android/libraries/rib-android/src/main/java/com/uber/rib/core/lifecycle/ActivityLifecycleEvent.java
+++ b/android/libraries/rib-android/src/main/java/com/uber/rib/core/lifecycle/ActivityLifecycleEvent.java
@@ -15,20 +15,22 @@
  */
 package com.uber.rib.core.lifecycle;
 
-import android.app.Activity;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
-
 import java.util.Locale;
 
 /** Lifecycle events that can be emitted by Activities. */
 public class ActivityLifecycleEvent implements ActivityEvent {
 
   private static final ActivityLifecycleEvent START_EVENT = new ActivityLifecycleEvent(Type.START);
-  private static final ActivityLifecycleEvent RESUME_EVENT = new ActivityLifecycleEvent(Type.RESUME);
+  private static final ActivityLifecycleEvent RESUME_EVENT =
+      new ActivityLifecycleEvent(Type.RESUME);
+  private static final ActivityLifecycleEvent USER_LEAVING_EVENT =
+      new ActivityLifecycleEvent(Type.USER_LEAVING);
   private static final ActivityLifecycleEvent PAUSE_EVENT = new ActivityLifecycleEvent(Type.PAUSE);
   private static final ActivityLifecycleEvent STOP_EVENT = new ActivityLifecycleEvent(Type.STOP);
-  private static final ActivityLifecycleEvent DESTROY_EVENT = new ActivityLifecycleEvent(Type.DESTROY);
+  private static final ActivityLifecycleEvent DESTROY_EVENT =
+      new ActivityLifecycleEvent(Type.DESTROY);
 
   private final Type type;
 
@@ -58,6 +60,8 @@ public class ActivityLifecycleEvent implements ActivityEvent {
         return START_EVENT;
       case RESUME:
         return RESUME_EVENT;
+      case USER_LEAVING:
+        return USER_LEAVING_EVENT;
       case PAUSE:
         return PAUSE_EVENT;
       case STOP:
@@ -87,6 +91,7 @@ public class ActivityLifecycleEvent implements ActivityEvent {
     CREATE,
     START,
     RESUME,
+    USER_LEAVING,
     PAUSE,
     STOP,
     DESTROY,

--- a/android/libraries/rib-android/src/test/java/com/uber/rib/core/RibActivityTest.java
+++ b/android/libraries/rib-android/src/test/java/com/uber/rib/core/RibActivityTest.java
@@ -23,7 +23,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.rib.android.R;
 import com.uber.rib.core.lifecycle.ActivityCallbackEvent;
@@ -230,7 +229,7 @@ public class RibActivityTest {
 
     @NonNull
     @Override
-    protected ViewRouter<?, ?, ?> createRouter(@NonNull ViewGroup parentViewGroup) {
+    protected ViewRouter<?, ?> createRouter(@NonNull ViewGroup parentViewGroup) {
       FrameLayout view = new FrameLayout(RuntimeEnvironment.application);
 
       InteractorComponent component = mock(InteractorComponent.class);
@@ -246,7 +245,7 @@ public class RibActivityTest {
   }
 
   private static class EmptyRouter
-      extends ViewRouter<FrameLayout, Interactor<ViewPresenter, ?>, InteractorComponent> {
+      extends ViewRouter<FrameLayout, Interactor<ViewPresenter, ?>> {
 
     EmptyRouter(
         @NonNull FrameLayout view,

--- a/android/libraries/rib-android/src/test/java/com/uber/rib/core/XRayTest.java
+++ b/android/libraries/rib-android/src/test/java/com/uber/rib/core/XRayTest.java
@@ -43,12 +43,12 @@ public class XRayTest {
 
   @Test
   public void apply_changesViewBackground() {
-    final ViewBuilder viewBuilder = mock(ViewBuilder.class);
+    final ViewRouter viewRouter = mock(ViewRouter.class);
     final View view = mock(View.class);
     when(view.getContext()).thenReturn(context);
 
-    XRay.apply(viewBuilder, view);
+    XRay.apply(viewRouter, view);
     verify(view).setBackground(any(Drawable.class));
-    verifyNoMoreInteractions(viewBuilder);
+    verifyNoMoreInteractions(viewRouter);
   }
 }

--- a/android/tutorials/tutorial1/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/tutorials/tutorial1/src/main/java/com/uber/rib/RootActivity.java
@@ -28,7 +28,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {
     });
     return rootBuilder.build(parentViewGroup);

--- a/android/tutorials/tutorial1/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/tutorials/tutorial1/src/main/java/com/uber/rib/root/RootRouter.java
@@ -19,7 +19,7 @@ package com.uber.rib.root;
 import com.uber.rib.core.ViewRouter;
 
 /** Adds and removes children of {@link RootBuilder.RootScope}. */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   RootRouter(RootView view, RootInteractor interactor, RootBuilder.Component component) {
     super(view, interactor, component);

--- a/android/tutorials/tutorial2/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/tutorials/tutorial2/src/main/java/com/uber/rib/RootActivity.java
@@ -27,7 +27,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {});
     return rootBuilder.build(parentViewGroup);
   }

--- a/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/RootRouter.java
@@ -23,7 +23,7 @@ import com.uber.rib.root.logged_out.LoggedOutBuilder;
 import com.uber.rib.root.logged_out.LoggedOutRouter;
 
 /** Adds and removes children of {@link RootBuilder.RootScope}. */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   private final LoggedOutBuilder loggedOutBuilder;
 

--- a/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
+++ b/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link OffGameBuilder.OffGameScope}.
  */
 public class OffGameRouter extends
-    ViewRouter<OffGameView, OffGameInteractor, OffGameBuilder.Component> {
+    ViewRouter<OffGameView, OffGameInteractor> {
 
   public OffGameRouter(
       OffGameView view,

--- a/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
+++ b/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link TicTacToeBuilder.TicTacToeScope}.
  */
 public class TicTacToeRouter extends
-    ViewRouter<TicTacToeView, TicTacToeInteractor, TicTacToeBuilder.Component> {
+    ViewRouter<TicTacToeView, TicTacToeInteractor> {
 
   public TicTacToeRouter(
       TicTacToeView view,

--- a/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
+++ b/android/tutorials/tutorial2/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
@@ -6,7 +6,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link LoggedOutBuilder.LoggedOutScope}.
  */
 public class LoggedOutRouter extends
-        ViewRouter<LoggedOutView, LoggedOutInteractor, LoggedOutBuilder.Component> {
+        ViewRouter<LoggedOutView, LoggedOutInteractor> {
 
     public LoggedOutRouter(
             LoggedOutView view,

--- a/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/RootActivity.java
@@ -27,7 +27,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {});
     return rootBuilder.build(parentViewGroup);
   }

--- a/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/RootRouter.java
@@ -26,7 +26,7 @@ import com.uber.rib.root.logged_out.LoggedOutRouter;
 /**
  * Adds and removes children of {@link RootBuilder.RootScope}.
  */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   private final LoggedOutBuilder loggedOutBuilder;
   private final LoggedInBuilder loggedInBuilder;

--- a/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
+++ b/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link OffGameBuilder.OffGameScope}.
  */
 public class OffGameRouter extends
-    ViewRouter<OffGameView, OffGameInteractor, OffGameBuilder.Component> {
+    ViewRouter<OffGameView, OffGameInteractor> {
 
   public OffGameRouter(
       OffGameView view,

--- a/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
+++ b/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link TicTacToeBuilder.TicTacToeScope}.
  */
 public class TicTacToeRouter extends
-    ViewRouter<TicTacToeView, TicTacToeInteractor, TicTacToeBuilder.Component> {
+    ViewRouter<TicTacToeView, TicTacToeInteractor> {
 
   public TicTacToeRouter(
       TicTacToeView view,

--- a/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
+++ b/android/tutorials/tutorial3-completed/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link LoggedOutBuilder.LoggedOutScope}.
  */
 public class LoggedOutRouter extends
-    ViewRouter<LoggedOutView, LoggedOutInteractor, LoggedOutBuilder.Component> {
+    ViewRouter<LoggedOutView, LoggedOutInteractor> {
 
   public LoggedOutRouter(
       LoggedOutView view,

--- a/android/tutorials/tutorial3/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/tutorials/tutorial3/src/main/java/com/uber/rib/RootActivity.java
@@ -27,7 +27,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {});
     return rootBuilder.build(parentViewGroup);
   }

--- a/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/RootRouter.java
@@ -26,7 +26,7 @@ import com.uber.rib.root.logged_out.LoggedOutRouter;
 /**
  * Adds and removes children of {@link RootBuilder.RootScope}.
  */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   private final LoggedOutBuilder loggedOutBuilder;
   private final LoggedInBuilder loggedInBuilder;

--- a/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
+++ b/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link OffGameBuilder.OffGameScope}.
  */
 public class OffGameRouter extends
-    ViewRouter<OffGameView, OffGameInteractor, OffGameBuilder.Component> {
+    ViewRouter<OffGameView, OffGameInteractor> {
 
   public OffGameRouter(
       OffGameView view,

--- a/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
+++ b/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link TicTacToeBuilder.TicTacToeScope}.
  */
 public class TicTacToeRouter extends
-    ViewRouter<TicTacToeView, TicTacToeInteractor, TicTacToeBuilder.Component> {
+    ViewRouter<TicTacToeView, TicTacToeInteractor> {
 
   public TicTacToeRouter(
       TicTacToeView view,

--- a/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
+++ b/android/tutorials/tutorial3/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link LoggedOutBuilder.LoggedOutScope}.
  */
 public class LoggedOutRouter extends
-    ViewRouter<LoggedOutView, LoggedOutInteractor, LoggedOutBuilder.Component> {
+    ViewRouter<LoggedOutView, LoggedOutInteractor> {
 
   public LoggedOutRouter(
       LoggedOutView view,

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/RootActivity.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/RootActivity.java
@@ -31,7 +31,6 @@ import com.uber.rib.root.RootBuilder;
 import com.uber.rib.root.RootInteractor;
 import com.uber.rib.root.RootRouter;
 import com.uber.rib.root.RootWorkflow;
-import com.uber.rib.root.RootWorkflowModel;
 import com.uber.rib.root.WorkflowFactory;
 
 import androidx.annotation.Nullable;
@@ -45,7 +44,7 @@ public class RootActivity extends RibActivity {
 
   @SuppressWarnings("unchecked")
   @Override
-  protected ViewRouter<?, ?, ?> createRouter(ViewGroup parentViewGroup) {
+  protected ViewRouter<?, ?> createRouter(ViewGroup parentViewGroup) {
     RootBuilder rootBuilder = new RootBuilder(new RootBuilder.ParentComponent() {});
     RootRouter router = rootBuilder.build(parentViewGroup);
     rootInteractor = router.getInteractor();

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/RootRouter.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/RootRouter.java
@@ -30,7 +30,7 @@ import com.uber.rib.root.logged_out.LoggedOutRouter;
 /**
  * Adds and removes children of {@link RootBuilder.RootScope}.
  */
-public class RootRouter extends ViewRouter<RootView, RootInteractor, RootBuilder.Component> {
+public class RootRouter extends ViewRouter<RootView, RootInteractor> {
 
   private final LoggedOutBuilder loggedOutBuilder;
   private final LoggedInBuilder loggedInBuilder;

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/off_game/OffGameRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link OffGameBuilder.OffGameScope}.
  */
 public class OffGameRouter extends
-    ViewRouter<OffGameView, OffGameInteractor, OffGameBuilder.Component> {
+    ViewRouter<OffGameView, OffGameInteractor> {
 
   public OffGameRouter(
       OffGameView view,

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/random_winner/RandomWinnerRouter.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/random_winner/RandomWinnerRouter.java
@@ -8,7 +8,7 @@ import com.uber.rib.core.ViewRouter;
  * TODO describe the possible child configurations of this scope.
  */
 public class RandomWinnerRouter extends
-        ViewRouter<RandomWinnerView, RandomWinnerInteractor, RandomWinnerBuilder.Component> {
+        ViewRouter<RandomWinnerView, RandomWinnerInteractor> {
 
     public RandomWinnerRouter(
             RandomWinnerView view,

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_in/tic_tac_toe/TicTacToeRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link TicTacToeBuilder.TicTacToeScope}.
  */
 public class TicTacToeRouter extends
-    ViewRouter<TicTacToeView, TicTacToeInteractor, TicTacToeBuilder.Component> {
+    ViewRouter<TicTacToeView, TicTacToeInteractor> {
 
   public TicTacToeRouter(
       TicTacToeView view,

--- a/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
+++ b/android/tutorials/tutorial4/src/main/java/com/uber/rib/root/logged_out/LoggedOutRouter.java
@@ -22,7 +22,7 @@ import com.uber.rib.core.ViewRouter;
  * Adds and removes children of {@link LoggedOutBuilder.LoggedOutScope}.
  */
 public class LoggedOutRouter extends
-    ViewRouter<LoggedOutView, LoggedOutInteractor, LoggedOutBuilder.Component> {
+    ViewRouter<LoggedOutView, LoggedOutInteractor> {
 
   public LoggedOutRouter(
       LoggedOutView view,


### PR DESCRIPTION
This PR aligns the `rib-android` module with our internal version as part of #392. The changes consist of:
- Add support for `onUserLeaveHint`, `onTrimMemory`, and `onPIPModeChanged`
- Remove Component type parameter from ViewRouter
- Bump Build Tools and Compile SDK to 30
- Updates to Xray for lazy init & naming the Router instead of Builder
- Test updates
- Reordering of imports & whitespace
