### PR TITLE
Add REPLACE_TOP RouterNavigator Flag

### DIFF
--- a/android/libraries/rib-router-navigator/src/main/java/com/uber/rib/core/RouterNavigator.java
+++ b/android/libraries/rib-router-navigator/src/main/java/com/uber/rib/core/RouterNavigator.java
@@ -58,7 +58,13 @@ public interface RouterNavigator<StateT extends RouterNavigatorState> {
     REORDER_TO_TOP,
 
     /** Clears the previous stack (no back stack) and pushes the state on to the top of the stack */
-    NEW_TASK
+    NEW_TASK,
+
+    /**
+     * Remove the top state in the stack if it is not empty and then push a new state to the top of
+     * the stack.
+     */
+    REPLACE_TOP
   }
 
   /** Pop the current state and rewind to the previous state (if there is a previous state). */

--- a/android/libraries/rib-router-navigator/src/main/java/com/uber/rib/core/StackRouterNavigator.java
+++ b/android/libraries/rib-router-navigator/src/main/java/com/uber/rib/core/StackRouterNavigator.java
@@ -175,6 +175,14 @@ public class StackRouterNavigator<StateT extends RouterNavigatorState>
         }
 
         break;
+      case REPLACE_TOP:
+        if (!navigationStack.isEmpty()) {
+          navigationStack.pop();
+        }
+        newRouterAndState = buildNewState(newState, attachTransition, detachTransition);
+        navigationStack.push(newRouterAndState);
+        attachInternal(currentRouterAndState, newRouterAndState, true);
+        break;
     }
   }
 

--- a/android/libraries/rib-router-navigator/src/test/java/com/uber/rib/core/StackRouterNavigatorTest.java
+++ b/android/libraries/rib-router-navigator/src/test/java/com/uber/rib/core/StackRouterNavigatorTest.java
@@ -553,6 +553,36 @@ public class StackRouterNavigatorTest {
   }
 
   @Test
+  public void pushReplaceTop_removeExistingTopOfStack_andShouldPushNewStateToTopOfStack() {
+    routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1);
+    routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2);
+
+    routerNavigator.pushState(
+            TestState.STATE_3,
+            StackRouterNavigator.Flag.REPLACE_TOP,
+            attachTransition3,
+            detachTransition3);
+
+    assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_3);
+    assertThat(routerNavigator.size()).isEqualTo(2);
+    routerNavigator.popState();
+    assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_1);
+    assertThat(routerNavigator.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void pushReplaceTop_whenStackIsEmpty_shouldPushNewStateToTopOfStack() {
+    routerNavigator.pushState(
+            TestState.STATE_1,
+            StackRouterNavigator.Flag.REPLACE_TOP,
+            attachTransition3,
+            detachTransition3);
+
+    assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_1);
+    assertThat(routerNavigator.size()).isEqualTo(1);
+  }
+
+  @Test
   public void
       pop_whenThereIsSomethingToPopTo_shouldRemoveCurrentItemAndReaddPreviousItemWithCorrectState() {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, null);


### PR DESCRIPTION
**Description**:

Adding a new flag REPLACE_TOP to pop top of the state in the stack if it exists and push new state into navigator. This mimics Android `finishActivity(); startActivity(Intent(...))`