### PR TITLE
Add integration with japicmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
       script:
         - cd android
         - ./gradlew spotlessCheck build
+        - ./gradlew japicmp
 
       env:
         - secure: "X1BegtP1L5RJwLKsb198RanMxXjHz0q9ta5GGqmRSuROI3sunp2tJFzQHxiYKbHNJ6t98a5tEGgX+rboQKvRA6zWZWXnGRiVZ2fBW/uIxI55yNPo5tRssjbzVUhllo9ffd/NONtFRJ7pS4csDqQtW/AvLTIl5JXj3K3ciBSc1ErLgnh7T0ycmivwoIgGVj3rI8/KVrD9QJ95p2T39UR3DdMseAUymrCeHpYxZqPhEHxWfPWWw2YVTd7tDoywALy2KFo2zGjsltqkRl4AICJE+c9DBGl4K4zrhDUGEfbqbtL1I+jnfhCjiB4AhqW2ysQNdSLRldpRVgi8hn3tWyIfuLOFD7kk99cHRCZEI1H3hqH+GveEC05y6N2JpI/UFBJ7bl4Vcz3P1xKIMxLauS+tg6yXIebia3ca7f8Kih5B8pyuFW2D3sUsmU6nFIT203WDZzYs/QOpplWUYXd6QqJqUPQk8Yi3WVxYlyIuY3M6aat0Uj1TMMWmrtFSe/SFXC7foZLKJNtgJ/FE+g6kt4IJSMW5M7Ecbgqds/d803k9A7/Qjf94bTgqFhb6E5mIEszI5mtb03GYc6rPJsNGiojvhil9szn3DDqlKZAmgyV2/RBFXwUcOK61KIU5/B+KS8dEAD3CWPaFvkIwcUrjd+JiYWhNFzxTbuqWqCMt1aG+wrI="

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ buildscript {
         classpath deps.build.gradlePlugins.android
         classpath deps.build.gradlePlugins.errorprone
         classpath deps.build.gradlePlugins.spotless
+        classpath deps.build.gradlePlugins.japicmp
     }
 }
 
@@ -94,6 +95,31 @@ subprojects {
     boolean isAndroidLibrary = project.name in androidLibraryProjects
     boolean isSample = project.path.startsWith(":demos:") || project.path.startsWith(":tutorials:")
     boolean usesErrorProne = project.name in useErrorProneProjects
+
+    if (isAndroidLibrary) {
+        apply plugin: 'me.champeau.gradle.japicmp'
+
+        configurations {
+            baseline
+        }
+
+        dependencies {
+            baseline("com.uber.rib:${project.name}:${LAST_VERSION_NAME}") {
+                transitive = false
+                force = true
+            }
+        }
+
+        task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'assemble') {
+            oldClasspath = configurations.baseline.collect { zipTree(it) }.first().filter { it == 'classes.jar'}
+            newClasspath = zipTree(file("$buildDir/outputs/aar/${project.name}-release.aar")).filter { it == 'classes.jar'}
+            onlyBinaryIncompatibleModified = true
+            failOnModification = true
+            txtOutputFile = file("$buildDir/reports/japi.txt")
+            ignoreMissingClasses = true
+            includeSynthetic = true
+        }
+    }
 
     afterEvaluate {
         if ((isAndroidLibrary || isSample) && usesErrorProne) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,6 +13,7 @@
 # org.gradle.parallel=true
 
 GROUP=com.uber.rib
+LAST_VERSION_NAME=0.10.1
 VERSION_NAME=0.10.2-SNAPSHOT
 POM_DESCRIPTION=RIBs is the cross-platform architecture behind many mobile apps at Uber. This framework is designed for mobile apps with a large number of engineers and nested states.
 POM_URL=https://github.com/uber/RIBs/

--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -25,6 +25,7 @@ def versions = [
     errorProne: '2.3.3',
     gjf: '1.7',
     intellij: "2017.2",
+    japicmp: '0.2.8',
     ktfmt: '0.23',
     ktlint: '0.41.0',
     rave: "2.0.0",
@@ -64,11 +65,12 @@ def build = [
     errorProneTestHelpers: "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
     nullAway: 'com.uber.nullaway:nullaway:0.9.0',
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:3.6.2',
+        android: 'com.android.tools.build:gradle:4.1.3',
         errorprone: "net.ltgt.gradle:gradle-errorprone-plugin:1.3.0",
         nullaway: "net.ltgt.gradle:gradle-nullaway-plugin:1.0.2",
         apt: "net.ltgt.gradle:gradle-apt-plugin:0.21",
-        spotless: "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotless}"
+        spotless: "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotless}",
+        japicmp: "me.champeau.gradle:japicmp-gradle-plugin:${versions.japicmp}",
     ]
 ]
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
May close #416.

Some points to highlight:
- To create a baseline config for comparison, I needed to bump the AGP version.
- I noticed that we do not have the current stable version anywhere (needed to fetch the latest published artifacts to use in the comparison), so I defined it in `gradle.properties`
