### PR TITLE
ISSUE-437: Add protected method to post events to callback relay

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -88,7 +88,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   @CallSuper
   public override fun onSaveInstanceState(outState: android.os.Bundle) {
     super.onSaveInstanceState(outState)
-    callbacksRelay.accept(createOnSaveInstanceStateEvent(outState))
+    onActivityCallbackEvent(createOnSaveInstanceStateEvent(outState))
     router?.saveInstanceStateInternal(Bundle(outState)) ?: throw NullPointerException("Router should not be null")
   }
 
@@ -107,13 +107,13 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   @CallSuper
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
-    callbacksRelay.accept(createNewIntent(intent))
+    onActivityCallbackEvent(createNewIntent(intent))
   }
 
   @CallSuper
   public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
-    callbacksRelay.accept(createOnActivityResultEvent(requestCode, resultCode, data))
+    onActivityCallbackEvent(createOnActivityResultEvent(requestCode, resultCode, data))
   }
 
   @CallSuper
@@ -142,22 +142,20 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   @CallSuper
   override fun onLowMemory() {
     super.onLowMemory()
-    callbacksRelay.accept(create(ActivityCallbackEvent.Type.LOW_MEMORY))
+    onActivityCallbackEvent(create(ActivityCallbackEvent.Type.LOW_MEMORY))
   }
 
   @CallSuper
   override fun onTrimMemory(level: Int) {
     super.onTrimMemory(level)
-    callbacksRelay.accept(createTrimMemoryEvent(level))
+    onActivityCallbackEvent(createTrimMemoryEvent(level))
   }
 
   override fun onPictureInPictureModeChanged(
     isInPictureInPictureMode: Boolean,
     newConfig: Configuration
   ) {
-    callbacksRelay.accept(
-      createPictureInPictureMode(isInPictureInPictureMode)
-    )
+    onActivityCallbackEvent(createPictureInPictureMode(isInPictureInPictureMode))
   }
 
   override fun onBackPressed() {
@@ -178,6 +176,10 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   override fun onUserLeaveHint() {
     lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.USER_LEAVING))
     super.onUserLeaveHint()
+  }
+
+  protected fun onActivityCallbackEvent(event: ActivityCallbackEvent) {
+    callbacksRelay.accept(event)
   }
 
   /**

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -21,6 +21,8 @@ import android.content.res.Configuration
 import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PROTECTED
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.PublishRelay
 import com.jakewharton.rxrelay2.Relay
@@ -178,7 +180,8 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
     super.onUserLeaveHint()
   }
 
-  protected fun onActivityCallbackEvent(event: ActivityCallbackEvent) {
+  @VisibleForTesting(otherwise = PROTECTED)
+  fun onActivityCallbackEvent(event: ActivityCallbackEvent) {
     callbacksRelay.accept(event)
   }
 

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -180,6 +180,11 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
     super.onUserLeaveHint()
   }
 
+  /**
+   * Invoked when an activity callback function is triggered. These can be of types
+   * [ActivityCallbackEvent.Type]. This allows VIPs activities to send [ActivityCallbackEvent]
+   * through the [callbacksRelay]
+   */
   @VisibleForTesting(otherwise = PROTECTED)
   fun onActivityCallbackEvent(event: ActivityCallbackEvent) {
     callbacksRelay.accept(event)

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
@@ -180,6 +180,16 @@ class RibActivityTest {
     create(ActivityLifecycleEvent.Type.CREATE)
   }
 
+  @Test
+  fun onActivityCallbackEvent_shouldTriggerCallbacksObservable() {
+    val activity: RibActivity = Robolectric.buildActivity(EmptyActivity::class.java).setup().get()
+    val testSub = TestObserver<ActivityCallbackEvent>()
+    activity.callbacks().subscribe(testSub)
+    activity.onActivityCallbackEvent(create(ActivityCallbackEvent.Type.LOW_MEMORY))
+    testSub.assertValueCount(1)
+    assertThat(testSub.values().firstOrNull()).isNotNull()
+  }
+
   private class EmptyActivity : RibActivity() {
     override fun onCreate(savedInstanceState: android.os.Bundle?) {
       setTheme(R.style.Theme_AppCompat)


### PR DESCRIPTION
- Add method onActivityCallbackEvent
- Change instances of callbacksRelay.accept to use the onActivityCallbackEvent() function

<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
I have described the issue [here](https://github.com/uber/RIBs/issues/437). Briefly we need to provide a method to be able to post events to the `callbacksRelay` so we can have a custom logic behind some callbacks like `onActivityResult`

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/RIBs/issues/437

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
