### PR TITLE
Change all class-only protocol keywords to AnyObject

### DIFF
--- a/ios/RIBs/Classes/Builder.swift
+++ b/ios/RIBs/Classes/Builder.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The base builder protocol that all builders should conform to.
-public protocol Buildable: class {}
+public protocol Buildable: AnyObject {}
 
 /// Utility that instantiates a RIB and sets up its internal wirings.
 open class Builder<DependencyType>: Buildable {

--- a/ios/RIBs/Classes/DI/Dependency.swift
+++ b/ios/RIBs/Classes/DI/Dependency.swift
@@ -20,7 +20,7 @@ import Foundation
 ///
 /// Subclasses should define a set of properties that are required by the module from the DI graph. A dependency is
 /// typically provided and satisfied by its immediate parent module.
-public protocol Dependency: class {}
+public protocol Dependency: AnyObject {}
 
 /// The special empty dependency.
 public protocol EmptyDependency: Dependency {}

--- a/ios/RIBs/Classes/Interactor.swift
+++ b/ios/RIBs/Classes/Interactor.swift
@@ -19,7 +19,7 @@ import RxSwift
 import UIKit
 
 /// Protocol defining the activeness of an interactor's scope.
-public protocol InteractorScope: class {
+public protocol InteractorScope: AnyObject {
 
     // The following properties must be declared in the base protocol, since `Router` internally invokes these methods.
     // In order to unit test router with a mock interactor, the mocked interactor first needs to conform to the custom

--- a/ios/RIBs/Classes/Presenter.swift
+++ b/ios/RIBs/Classes/Presenter.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The base protocol for all `Presenter`s.
-public protocol Presentable: class {}
+public protocol Presentable: AnyObject {}
 
 /// The base class of all `Presenter`s. A `Presenter` translates business models into values the corresponding
 /// `ViewController` can consume and display. It also maps UI events to business logic method, invoked to

--- a/ios/RIBs/Classes/Router.swift
+++ b/ios/RIBs/Classes/Router.swift
@@ -24,7 +24,7 @@ public enum RouterLifecycle {
 }
 
 /// The scope of a `Router`, defining various lifecycles of a `Router`.
-public protocol RouterScope: class {
+public protocol RouterScope: AnyObject {
 
     /// An observable that emits values when the router scope reaches its corresponding life-cycle stages. This
     /// observable completes when the router scope is deallocated.

--- a/ios/RIBs/Classes/ViewControllable.swift
+++ b/ios/RIBs/Classes/ViewControllable.swift
@@ -17,7 +17,7 @@
 import UIKit
 
 /// Basic interface between a `Router` and the UIKit `UIViewController`.
-public protocol ViewControllable: class {
+public protocol ViewControllable: AnyObject {
 
     var uiviewController: UIViewController { get }
 }

--- a/ios/RIBs/Classes/Worker/Worker.swift
+++ b/ios/RIBs/Classes/Worker/Worker.swift
@@ -20,7 +20,7 @@ import RxSwift
 ///
 /// `Worker`s are always bound to an `Interactor`. A `Worker` can only start if its bound `Interactor` is active.
 /// It is stopped when its bound interactor is deactivated.
-public protocol Working: class {
+public protocol Working: AnyObject {
 
     /// Starts the `Worker`.
     ///

--- a/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/ios/tooling/RIB.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -8,7 +8,7 @@ protocol ___VARIABLE_productName___Routing: Routing {
     // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
 }
 
-protocol ___VARIABLE_productName___Listener: class {
+protocol ___VARIABLE_productName___Listener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -12,7 +12,7 @@ protocol ___VARIABLE_productName___Presentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol ___VARIABLE_productName___Listener: class {
+protocol ___VARIABLE_productName___Listener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
+++ b/ios/tooling/RIB.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
@@ -4,7 +4,7 @@ import RIBs
 import RxSwift
 import UIKit
 
-protocol ___VARIABLE_productName___PresentableListener: class {
+protocol ___VARIABLE_productName___PresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial1/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial1/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial1/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial1/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -26,7 +26,7 @@ protocol LoggedOutPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol LoggedOutListener: class {
+protocol LoggedOutListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutViewController.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/LoggedOut/LoggedOutViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol LoggedOutPresentableListener: class {
+protocol LoggedOutPresentableListener: AnyObject {
     func login(withPlayer1Name: String?, player2Name: String?)
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -27,7 +27,7 @@ protocol TicTacToePresentable: Presentable {
     func announce(winner: PlayerType)
 }
 
-protocol TicTacToeListener: class {
+protocol TicTacToeListener: AnyObject {
     func gameDidEnd()
 }
 

--- a/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeViewController.swift
+++ b/ios/tutorials/tutorial2/TicTacToe/TicTacToe/TicTacToeViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol TicTacToePresentableListener: class {
+protocol TicTacToePresentableListener: AnyObject {
     func placeCurrentPlayerMark(atRow row: Int, col: Int)
     func closeGame()
 }

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -28,7 +28,7 @@ protocol LoggedInRouting: Routing {
     func routeToOffGame()
 }
 
-protocol LoggedInListener: class {
+protocol LoggedInListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -26,7 +26,7 @@ protocol LoggedOutPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol LoggedOutListener: class {
+protocol LoggedOutListener: AnyObject {
     func didLogin(withPlayer1Name player1Name: String, player2Name: String)
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutViewController.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/LoggedOut/LoggedOutViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol LoggedOutPresentableListener: class {
+protocol LoggedOutPresentableListener: AnyObject {
     func login(withPlayer1Name: String?, player2Name: String?)
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Models/ScoreStream.swift
@@ -26,7 +26,7 @@ struct Score {
     }
 }
 
-protocol ScoreStream: class {
+protocol ScoreStream: AnyObject {
     var score: Observable<Score> { get }
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameInteractor.swift
@@ -26,7 +26,7 @@ protocol OffGamePresentable: Presentable {
     func set(score: Score)
 }
 
-protocol OffGameListener: class {
+protocol OffGameListener: AnyObject {
     func startTicTacToe()
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameViewController.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/OffGame/OffGameViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol OffGamePresentableListener: class {
+protocol OffGamePresentableListener: AnyObject {
     func startGame()
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -27,7 +27,7 @@ protocol TicTacToePresentable: Presentable {
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }
 
-protocol TicTacToeListener: class {
+protocol TicTacToeListener: AnyObject {
     func gameDidEnd(withWinner winner: PlayerType?)
 }
 

--- a/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeViewController.swift
+++ b/ios/tutorials/tutorial3-completed/TicTacToe/TicTacToe/TicTacToeViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol TicTacToePresentableListener: class {
+protocol TicTacToePresentableListener: AnyObject {
     func placeCurrentPlayerMark(atRow row: Int, col: Int)
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -28,7 +28,7 @@ protocol LoggedInRouting: Routing {
     func routeToOffGame()
 }
 
-protocol LoggedInListener: class {
+protocol LoggedInListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -26,7 +26,7 @@ protocol LoggedOutPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol LoggedOutListener: class {
+protocol LoggedOutListener: AnyObject {
     func didLogin(withPlayer1Name player1Name: String, player2Name: String)
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutViewController.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/LoggedOut/LoggedOutViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol LoggedOutPresentableListener: class {
+protocol LoggedOutPresentableListener: AnyObject {
     func login(withPlayer1Name: String?, player2Name: String?)
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameInteractor.swift
@@ -26,7 +26,7 @@ protocol OffGamePresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol OffGameListener: class {
+protocol OffGameListener: AnyObject {
     func startTicTacToe()
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameViewController.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/OffGame/OffGameViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol OffGamePresentableListener: class {
+protocol OffGamePresentableListener: AnyObject {
     func startGame()
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -27,7 +27,7 @@ protocol TicTacToePresentable: Presentable {
     func announce(winner: PlayerType)
 }
 
-protocol TicTacToeListener: class {
+protocol TicTacToeListener: AnyObject {
     func gameDidEnd()
 }
 

--- a/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeViewController.swift
+++ b/ios/tutorials/tutorial3/TicTacToe/TicTacToe/TicTacToeViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol TicTacToePresentableListener: class {
+protocol TicTacToePresentableListener: AnyObject {
     func placeCurrentPlayerMark(atRow row: Int, col: Int)
     func closeGame()
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ActionableItems/LoggedInActionableItem.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ActionableItems/LoggedInActionableItem.swift
@@ -16,6 +16,6 @@
 
 import RxSwift
 
-public protocol LoggedInActionableItem: class {
+public protocol LoggedInActionableItem: AnyObject {
     func launchGame(with id: String?) -> Observable<(LoggedInActionableItem, ())>
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ActionableItems/RootActionableItem.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ActionableItems/RootActionableItem.swift
@@ -16,6 +16,6 @@
 
 import RxSwift
 
-public protocol RootActionableItem: class {
+public protocol RootActionableItem: AnyObject {
     func waitForLogin() -> Observable<(LoggedInActionableItem, ())>
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/AppStart/AppDelegate.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/AppStart/AppDelegate.swift
@@ -56,6 +56,6 @@ public class AppDelegate: UIResponder, UIApplicationDelegate {
     private var urlHandler: UrlHandler?
 }
 
-protocol UrlHandler: class {
+protocol UrlHandler: AnyObject {
     func handle(_ url: URL)
 }

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/Game.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/Game.swift
@@ -16,7 +16,7 @@
 
 import RIBs
 
-public protocol GameListener: class {
+public protocol GameListener: AnyObject {
     func gameDidEnd(with winner: PlayerType?)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -23,7 +23,7 @@ protocol LoggedInRouting: Routing {
     func routeToGame(with gameBuilder: GameBuildable)
 }
 
-protocol LoggedInListener: class {
+protocol LoggedInListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -26,7 +26,7 @@ protocol LoggedOutPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol LoggedOutListener: class {
+protocol LoggedOutListener: AnyObject {
     func didLogin(withPlayer1Name player1Name: String, player2Name: String)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/LoggedOut/LoggedOutViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol LoggedOutPresentableListener: class {
+protocol LoggedOutPresentableListener: AnyObject {
     func login(withPlayer1Name: String?, player2Name: String?)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Models/ScoreStream.swift
@@ -26,7 +26,7 @@ public struct Score {
     }
 }
 
-public protocol ScoreStream: class {
+public protocol ScoreStream: AnyObject {
     var score: Observable<Score> { get }
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameInteractor.swift
@@ -26,7 +26,7 @@ protocol OffGamePresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol OffGameListener: class {
+protocol OffGameListener: AnyObject {
     func startGame(with gameBuilder: GameBuildable)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/OffGame/OffGameViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol OffGamePresentableListener: class {
+protocol OffGamePresentableListener: AnyObject {
     func start(_ game: Game)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinInteractor.swift
@@ -26,7 +26,7 @@ protocol RandomWinPresentable: Presentable {
     func announce(winner: PlayerType, withCompletionHandler handler: @escaping () -> ())
 }
 
-public protocol RandomWinListener: class {
+public protocol RandomWinListener: AnyObject {
     func didRandomlyWin(with player: PlayerType)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/RandomWin/RandomWinViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol RandomWinPresentableListener: class {
+protocol RandomWinPresentableListener: AnyObject {
     func determineWinner()
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
@@ -26,7 +26,7 @@ protocol BasicScoreBoardPresentable: Presentable {
     func set(score: Score)
 }
 
-public protocol BasicScoreBoardListener: class {
+public protocol BasicScoreBoardListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/ScoreBoard/BasicScoreBoardViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol BasicScoreBoardPresentableListener: class {
+protocol BasicScoreBoardPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -27,7 +27,7 @@ protocol TicTacToePresentable: Presentable {
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }
 
-public protocol TicTacToeListener: class {
+public protocol TicTacToeListener: AnyObject {
     func ticTacToeDidEnd(with winner: PlayerType?)
 }
 

--- a/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeViewController.swift
+++ b/ios/tutorials/tutorial4-completed/TicTacToe/TicTacToe/TicTacToeViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol TicTacToePresentableListener: class {
+protocol TicTacToePresentableListener: AnyObject {
     func placeCurrentPlayerMark(atRow row: Int, col: Int)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/ActionableItems/RootActionableItem.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/ActionableItems/RootActionableItem.swift
@@ -16,6 +16,6 @@
 
 import RxSwift
 
-public protocol RootActionableItem: class {
+public protocol RootActionableItem: AnyObject {
 
 }

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedIn/Game.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedIn/Game.swift
@@ -16,7 +16,7 @@
 
 import RIBs
 
-public protocol GameListener: class {
+public protocol GameListener: AnyObject {
     func gameDidEnd(with winner: PlayerType?)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedIn/LoggedInInteractor.swift
@@ -23,7 +23,7 @@ protocol LoggedInRouting: Routing {
     func routeToGame(with gameBuilder: GameBuildable)
 }
 
-protocol LoggedInListener: class {
+protocol LoggedInListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutInteractor.swift
@@ -26,7 +26,7 @@ protocol LoggedOutPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol LoggedOutListener: class {
+protocol LoggedOutListener: AnyObject {
     func didLogin(withPlayer1Name player1Name: String, player2Name: String)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/LoggedOut/LoggedOutViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol LoggedOutPresentableListener: class {
+protocol LoggedOutPresentableListener: AnyObject {
     func login(withPlayer1Name: String?, player2Name: String?)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/Models/ScoreStream.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Models/ScoreStream.swift
@@ -26,7 +26,7 @@ public struct Score {
     }
 }
 
-public protocol ScoreStream: class {
+public protocol ScoreStream: AnyObject {
     var score: Observable<Score> { get }
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameInteractor.swift
@@ -26,7 +26,7 @@ protocol OffGamePresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol OffGameListener: class {
+protocol OffGameListener: AnyObject {
     func startGame(with gameBuilder: GameBuildable)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/OffGame/OffGameViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol OffGamePresentableListener: class {
+protocol OffGamePresentableListener: AnyObject {
     func start(_ game: Game)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinInteractor.swift
@@ -26,7 +26,7 @@ protocol RandomWinPresentable: Presentable {
     func announce(winner: PlayerType, withCompletionHandler handler: @escaping () -> ())
 }
 
-public protocol RandomWinListener: class {
+public protocol RandomWinListener: AnyObject {
     func didRandomlyWin(with player: PlayerType)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/RandomWin/RandomWinViewController.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-protocol RandomWinPresentableListener: class {
+protocol RandomWinPresentableListener: AnyObject {
     func determineWinner()
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/Root/RootInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Root/RootInteractor.swift
@@ -26,7 +26,7 @@ protocol RootPresentable: Presentable {
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol RootListener: class {
+protocol RootListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/Root/RootViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/Root/RootViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol RootPresentableListener: class {
+protocol RootPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardInteractor.swift
@@ -26,7 +26,7 @@ protocol BasicScoreBoardPresentable: Presentable {
     func set(score: Score)
 }
 
-public protocol BasicScoreBoardListener: class {
+public protocol BasicScoreBoardListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/ScoreBoard/BasicScoreBoardViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol BasicScoreBoardPresentableListener: class {
+protocol BasicScoreBoardPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.

--- a/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeInteractor.swift
@@ -27,7 +27,7 @@ protocol TicTacToePresentable: Presentable {
     func announce(winner: PlayerType?, withCompletionHandler handler: @escaping () -> ())
 }
 
-public protocol TicTacToeListener: class {
+public protocol TicTacToeListener: AnyObject {
     func ticTacToeDidEnd(with winner: PlayerType?)
 }
 

--- a/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeViewController.swift
+++ b/ios/tutorials/tutorial4/TicTacToe/TicTacToe/TicTacToeViewController.swift
@@ -18,7 +18,7 @@ import RIBs
 import SnapKit
 import UIKit
 
-protocol TicTacToePresentableListener: class {
+protocol TicTacToePresentableListener: AnyObject {
     func placeCurrentPlayerMark(atRow row: Int, col: Int)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: 
From Swift 4, `class` keyword is deprecated. Warnings started to occur on Xcode12.5.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
