### PR TITLE
More followup fixes for Kotlin RIBs

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -79,7 +79,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
     val wrappedBundle: Bundle? = if (savedInstanceState != null) Bundle(savedInstanceState) else null
     router = createRouter(rootViewGroup)
     router?.let {
-      it.dispatchAttachInternal(wrappedBundle)
+      it.dispatchAttach(wrappedBundle)
       rootViewGroup.addView(it.view)
       RibEvents.getInstance().emitEvent(RibEventType.ATTACHED, it, null)
     }
@@ -132,7 +132,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   override fun onDestroy() {
     lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.DESTROY))
     router?.let {
-      it.dispatchDetachInternal()
+      it.dispatchDetach()
       RibEvents.getInstance().emitEvent(RibEventType.DETACHED, it, null)
     }
     router = null

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
@@ -41,14 +41,6 @@ abstract class ViewRouter<V : View, I : Interactor<*, *>> : Router<I> {
     }
   }
 
-  fun dispatchAttachInternal(savedInstanceState: Bundle?) {
-    dispatchAttach(savedInstanceState)
-  }
-
-  fun dispatchDetachInternal() {
-    dispatchDetach()
-  }
-
   internal fun saveInstanceStateInternal(outState: Bundle) {
     saveInstanceState(outState)
   }

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile deps.external.reactiveStreams
     compile deps.external.rxrelay2
     compile deps.external.rxjava2
+    compile deps.kotlin.stdlib
     compile deps.uber.autodispose
     api deps.uber.autodisposeLifecycle
     compile deps.apt.javaxInject

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -38,21 +38,13 @@ abstract class Presenter : ScopeProvider {
   protected var isLoaded = false
     private set
 
-  internal fun dispatchLoadInternal() {
-    dispatchLoad()
-  }
-
-  protected open fun dispatchLoad() {
+  public open fun dispatchLoad() {
     isLoaded = true
     lifecycleRelay.accept(PresenterEvent.LOADED)
     didLoad()
   }
 
-  internal fun dispatchUnloadInternal() {
-    dispatchLoad()
-  }
-
-  protected open fun dispatchUnload() {
+  public open fun dispatchUnload() {
     isLoaded = false
     willUnload()
     lifecycleRelay.accept(PresenterEvent.UNLOADED)

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
@@ -84,26 +84,7 @@ abstract class Router<I : InteractorType> protected constructor(
   protected open fun willDetach() {}
 
   @MainThread
-  internal fun attachChildInternal(childRouter: Router<*>) {
-    attachChildInternal(childRouter, childRouter.javaClass.name)
-  }
-
-  /**
-   * Attaches a child router to this router. This method will automatically tag the child router by
-   * its class name to namespace its saved instance state [Bundle] object.
-   *
-   *
-   * If you have multiple children of the same class, use [Router.attachChild] to specify a custom tag.
-   *
-   * @param childRouter the [Router] to be attached.
-   */
-  @MainThread
-  internal fun attachChildInternal(childRouter: Router<*>, tag: String = childRouter.javaClass.name) {
-    attachChild(childRouter, tag)
-  }
-
-  @MainThread
-  protected open fun attachChild(childRouter: Router<*>) {
+  public open fun attachChild(childRouter: Router<*>) {
     attachChild(childRouter, childRouter.javaClass.name)
   }
 
@@ -114,7 +95,7 @@ abstract class Router<I : InteractorType> protected constructor(
    * @param tag an identifier to namespace saved instance state [Bundle] objects.
    */
   @MainThread
-  protected open fun attachChild(childRouter: Router<*>, tag: String) {
+  public open fun attachChild(childRouter: Router<*>, tag: String) {
     for (child in children) {
       if (tag == child.tag) {
         Rib.getConfiguration().handleNonFatalWarning(
@@ -138,11 +119,6 @@ abstract class Router<I : InteractorType> protected constructor(
     childRouter.dispatchAttach(childBundle, tag)
   }
 
-  @MainThread
-  internal fun detachChildInternal(childRouter: Router<*>) {
-    detachChild(childRouter)
-  }
-
   /**
    * Detaches the {@param childFactory} from the current [Interactor]. NOTE: No consumers of
    * this API should ever keep a reference to the detached child router, leak canary will enforce
@@ -154,7 +130,7 @@ abstract class Router<I : InteractorType> protected constructor(
    * @param childRouter the [Router] to be detached.
    */
   @MainThread
-  protected open fun detachChild(childRouter: Router<*>) {
+  public open fun detachChild(childRouter: Router<*>) {
     val isChildRemoved = children.remove(childRouter)
     val interactor = childRouter.interactor
     ribRefWatcher.watchDeletedObject(interactor)
@@ -171,23 +147,14 @@ abstract class Router<I : InteractorType> protected constructor(
     }
   }
 
-  internal fun dispatchAttachInternal(savedInstanceState: Bundle?) {
-    dispatchAttach(savedInstanceState)
-  }
-
-  internal fun dispatchAttachInternal(savedInstanceState: Bundle?, tag: String) {
-    dispatchAttach(savedInstanceState, tag)
-  }
-
   @CallSuper
-  @Initializer
-  protected open fun dispatchAttach(savedInstanceState: Bundle?) {
+  public open fun dispatchAttach(savedInstanceState: Bundle?) {
     dispatchAttach(savedInstanceState, javaClass.name)
   }
 
   @CallSuper
   @Initializer
-  protected open fun dispatchAttach(savedInstanceState: Bundle?, tag: String) {
+  public open fun dispatchAttach(savedInstanceState: Bundle?, tag: String) {
     checkForMainThread()
     if (!isLoaded) {
       isLoaded = true
@@ -200,17 +167,13 @@ abstract class Router<I : InteractorType> protected constructor(
     if (this.savedInstanceState != null) {
       interactorBundle = this.savedInstanceState!!.getBundleExtra(KEY_INTERACTOR)
     }
-    interactorGeneric.dispatchAttachInternal(interactorBundle)
+    interactorGeneric.dispatchAttach(interactorBundle)
   }
 
-  internal fun dispatchDetachInternal() {
-    dispatchDetach()
-  }
-
-  protected open fun dispatchDetach() {
+  public open fun dispatchDetach() {
     checkForMainThread()
 
-    interactorGeneric.dispatchDetachInternal()
+    interactorGeneric.dispatchDetach()
     willDetach()
     for (child in children) {
       detachChild(child)

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
@@ -50,22 +50,22 @@ class InteractorAndRouterTest {
   @Test
   fun attach_shouldAttachChildController() {
     // When.
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
 
     // Then.
-    verify(childInteractor).dispatchAttachInternal(null)
+    verify(childInteractor).dispatchAttach(null)
   }
 
   @Test
   fun detach_shouldDetachChildController() {
     // Given.
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
 
     // When.
-    router.dispatchDetachInternal()
+    router.dispatchDetach()
 
     // Then.
-    verify(childInteractor).dispatchDetachInternal()
+    verify(childInteractor).dispatchDetach()
   }
 
   @Test
@@ -103,7 +103,7 @@ class InteractorAndRouterTest {
     val router = TestRouterA(parentInteractor, component)
     val parentObserver = RecordingObserver<InteractorEvent>()
     parentInteractor.lifecycle().subscribe(parentObserver)
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
     Truth.assertThat(parentObserver.takeNext()).isEqualTo(InteractorEvent.ACTIVE)
     val childA = TestChildInteractor()
     val childComponent: InteractorComponent<TestPresenter, TestChildInteractor> = object : InteractorComponent<TestPresenter, TestChildInteractor> {
@@ -115,15 +115,15 @@ class InteractorAndRouterTest {
     val childRouter = TestChildRouter(childA, childComponent)
     val childObserverA = RecordingObserver<InteractorEvent>()
     childA.lifecycle().subscribe(childObserverA)
-    router.attachChildInternal(childRouter)
+    router.attachChild(childRouter)
     Truth.assertThat(childObserverA.takeNext()).isEqualTo(InteractorEvent.ACTIVE)
     val childB = TestChildInteractor()
     val childObserverB = RecordingObserver<InteractorEvent>()
     childB.lifecycle().subscribe(childObserverB)
     val childBRouter = TestChildRouter(childB, childComponent)
-    childRouter.attachChildInternal(childBRouter)
+    childRouter.attachChild(childBRouter)
     Truth.assertThat(childObserverB.takeNext()).isEqualTo(InteractorEvent.ACTIVE)
-    router.dispatchDetachInternal()
+    router.dispatchDetach()
     Truth.assertThat(parentObserver.takeNext()).isEqualTo(InteractorEvent.INACTIVE)
     Truth.assertThat(childObserverA.takeNext()).isEqualTo(InteractorEvent.INACTIVE)
     Truth.assertThat(childObserverB.takeNext()).isEqualTo(InteractorEvent.INACTIVE)
@@ -139,14 +139,14 @@ class InteractorAndRouterTest {
       }
     }
     val router = TestRouterB(component, rootInteractor, ribRefWatcher)
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
     val childInteractor = TestInteractorB()
     val childRouter = TestRouterB(childInteractor, component)
-    router.attachChildInternal(childRouter)
+    router.attachChild(childRouter)
     verify(ribRefWatcher, never()).watchDeletedObject(anyObject())
 
     // Action: Detach the child interactor.
-    router.detachChildInternal(childRouter)
+    router.detachChild(childRouter)
 
     // Verify: the reference watcher observes the detached interactor and child.
     verify(ribRefWatcher).watchDeletedObject(eq(childInteractor))
@@ -165,7 +165,7 @@ class InteractorAndRouterTest {
     verify(ribRefWatcher, never()).watchDeletedObject(anyObject())
 
     // Action: Detach all child interactors.
-    rootRouter.detachChildInternal(child)
+    rootRouter.detachChild(child)
 
     // Verify: called four times. Twice for each interactor.
     verify(ribRefWatcher, times(2)).watchDeletedObject(anyObject())
@@ -178,11 +178,11 @@ class InteractorAndRouterTest {
         return TestPresenter()
       }
     }
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
     val childRouter1 = TestRouterB(component, TestInteractorB(), ribRefWatcher)
     val childRouter2 = TestRouterB(component, TestInteractorB(), ribRefWatcher)
-    router.attachChildInternal(childRouter1)
-    childRouter1.attachChildInternal(childRouter2)
+    router.attachChild(childRouter1)
+    childRouter1.attachChild(childRouter2)
     return childRouter1
   }
 
@@ -190,7 +190,7 @@ class InteractorAndRouterTest {
     override fun didBecomeActive(savedInstanceState: Bundle?) {
       super.didBecomeActive(savedInstanceState)
       val router: Router<*> = FakeRouter(mChildInteractor, getInstance(), Thread.currentThread())
-      this.router.attachChildInternal(router)
+      this.router.attachChild(router)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RouterTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RouterTest.kt
@@ -44,7 +44,7 @@ class RouterTest {
         didLoad.set(true)
       }
     }
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
     assertThat(didLoad.get()).isTrue()
   }
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
@@ -231,7 +231,7 @@ open class StackRouterNavigator<StateT : RouterNavigatorState>(private val hostR
         Locale.getDefault(), "Attaching %s as a child of %s", toRouterName, hostRouterName
       )
     )
-    hostRouter.attachChildInternal(toRouterState.router)
+    hostRouter.attachChild(toRouterState.router)
   }
 
   /**
@@ -276,7 +276,7 @@ open class StackRouterNavigator<StateT : RouterNavigatorState>(private val hostR
       )
     }
     log(String.format(Locale.getDefault(), "Detaching %s from %s", fromRouterName, hostRouterName))
-    hostRouter.detachChildInternal(fromRouterState.router)
+    hostRouter.detachChild(fromRouterState.router)
     if (callback != null) {
       log(
         String.format(

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
@@ -78,12 +78,12 @@ class StackRouterNavigatorTest {
   fun pushRetained_whenNotInitialPush_shouldRunPreviousDetachRunnerAndRunNewAttachRunnerWithCorrectState() {
     routerNavigator.pushRetainedState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushRetainedState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
       .willDetachFromHost(router1, TestState.STATE_1, TestState.STATE_2, true)
-    verify(hostRouter).detachChildInternal(router1)
+    verify(hostRouter).detachChild(router1)
     verify(attachTransition2).willAttachToHost(router2, TestState.STATE_1, TestState.STATE_2, true)
     verifyZeroInteractions(detachTransition2)
   }
@@ -92,12 +92,12 @@ class StackRouterNavigatorTest {
   fun pushTransientDeprecated_whenNotInitialPush_shouldRunPreviousDetachRunnerAndRunNewAttachRunnerWithCorrectState() {
     routerNavigator.pushRetainedState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushTransientState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
       .willDetachFromHost(router1, TestState.STATE_1, TestState.STATE_2, true)
-    verify(hostRouter).detachChildInternal(router1)
+    verify(hostRouter).detachChild(router1)
     verify(attachTransition2).willAttachToHost(router2, TestState.STATE_1, TestState.STATE_2, true)
     verifyZeroInteractions(detachTransition2)
   }
@@ -105,12 +105,12 @@ class StackRouterNavigatorTest {
   @Test
   fun pushRetained_whenChildRouterSwitchesStateImmediately_shouldSwitchToCorrectState() {
     val hostRouter: Router<*> = mock {
-      on { attachChildInternal(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
+      on { attachChild(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
     }
     routerNavigator = StackRouterNavigator(hostRouter)
     routerNavigator.pushRetainedState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushRetainedState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
@@ -126,12 +126,12 @@ class StackRouterNavigatorTest {
   @Test
   fun pushTransientDeprecated_whenChildRouterSwitchesStateImmediately_shouldSwitchToCorrectState() {
     val hostRouter: Router<*> = mock {
-      on { attachChildInternal(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
+      on { attachChild(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
     }
     routerNavigator = StackRouterNavigator(hostRouter)
     routerNavigator.pushRetainedState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushTransientState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
@@ -180,12 +180,12 @@ class StackRouterNavigatorTest {
   fun pushDefault_whenNotInitialPush_shouldRunPreviousDetachRunnerAndRunNewAttachRunnerWithCorrectState() {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
       .willDetachFromHost(router1, TestState.STATE_1, TestState.STATE_2, true)
-    verify(hostRouter).detachChildInternal(router1)
+    verify(hostRouter).detachChild(router1)
     verify(attachTransition2).willAttachToHost(router2, TestState.STATE_1, TestState.STATE_2, true)
     verifyZeroInteractions(detachTransition2)
   }
@@ -194,7 +194,7 @@ class StackRouterNavigatorTest {
   fun pushTransient_whenNotInitialPush_shouldRunPreviousDetachRunnerAndRunNewAttachRunnerWithCorrectState() {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushState(
       TestState.STATE_2,
@@ -204,7 +204,7 @@ class StackRouterNavigatorTest {
     )
     verify(detachTransition1)
       .willDetachFromHost(router1, TestState.STATE_1, TestState.STATE_2, true)
-    verify(hostRouter).detachChildInternal(router1)
+    verify(hostRouter).detachChild(router1)
     verify(attachTransition2).willAttachToHost(router2, TestState.STATE_1, TestState.STATE_2, true)
     verifyZeroInteractions(detachTransition2)
   }
@@ -212,12 +212,12 @@ class StackRouterNavigatorTest {
   @Test
   fun pushDefault_whenChildRouterSwitchesStateImmediately_shouldSwitchToCorrectState() {
     val hostRouter: Router<*> = mock {
-      on { attachChildInternal(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
+      on { attachChild(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
     }
     routerNavigator = StackRouterNavigator(hostRouter)
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
     verify(detachTransition1)
@@ -233,12 +233,12 @@ class StackRouterNavigatorTest {
   @Test
   fun pushTransient_whenChildRouterSwitchesStateImmediately_shouldSwitchToCorrectState() {
     val hostRouter: Router<*> = mock {
-      on { attachChildInternal(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
+      on { attachChild(router2) } doAnswer { routerNavigator.pushState(TestState.STATE_3, attachTransition3, detachTransition3) }
     }
     routerNavigator = StackRouterNavigator(hostRouter)
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     verify(attachTransition1).willAttachToHost(router1, null, TestState.STATE_1, true)
-    verify(hostRouter).attachChildInternal(router1)
+    verify(hostRouter).attachChild(router1)
     verifyZeroInteractions(detachTransition1)
     routerNavigator.pushState(
       TestState.STATE_2,
@@ -516,7 +516,7 @@ class StackRouterNavigatorTest {
     routerNavigator.popState()
     verify(detachTransition2)
       .willDetachFromHost(router2, TestState.STATE_2, TestState.STATE_1, false)
-    verify(hostRouter).detachChildInternal(router2)
+    verify(hostRouter).detachChild(router2)
     verify(attachTransition1)
       .willAttachToHost(router1, TestState.STATE_2, TestState.STATE_1, false)
   }
@@ -541,7 +541,7 @@ class StackRouterNavigatorTest {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     routerNavigator.popState()
     verify(detachTransition1).willDetachFromHost(router1, TestState.STATE_1, null, false)
-    verify(hostRouter).detachChildInternal(router1)
+    verify(hostRouter).detachChild(router1)
   }
 
   @Test

--- a/android/libraries/rib-test/build.gradle
+++ b/android/libraries/rib-test/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     api deps.test.junit
     api deps.test.truth
     api deps.test.mockito
+    implementation deps.test.mockitoKotlin
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
@@ -15,10 +15,10 @@
  */
 package com.uber.rib.core
 
+import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.verify
 import org.mockito.AdditionalMatchers.or
-import org.mockito.Matchers.isA
-import org.mockito.Matchers.isNull
-import org.mockito.Mockito.verify
 
 /** The helper to test [Interactor].  */
 object InteractorHelper {
@@ -41,7 +41,7 @@ object InteractorHelper {
   ) {
     interactor.actualPresenter = presenter
     interactor.setRouterInternal(router)
-    interactor.dispatchAttachInternal(savedInstanceState)
+    interactor.dispatchAttach(savedInstanceState)
   }
 
   /**
@@ -52,7 +52,7 @@ object InteractorHelper {
    */
   @JvmStatic
   open fun reattach(interactor: Interactor<*, *>, savedInstanceState: Bundle?) {
-    interactor.dispatchAttachInternal(savedInstanceState)
+    interactor.dispatchAttach(savedInstanceState)
   }
 
   /**
@@ -62,7 +62,7 @@ object InteractorHelper {
    */
   @JvmStatic
   open fun detach(controller: Interactor<*, *>) {
-    controller.dispatchDetachInternal()
+    controller.dispatchDetach()
   }
 
   /**
@@ -72,7 +72,7 @@ object InteractorHelper {
    */
   @JvmStatic
   open fun verifyAttached(interactor: Interactor<*, *>) {
-    verify(interactor).dispatchAttachInternal(or(isNull(Bundle::class.java), isA(Bundle::class.java)))
+    verify(interactor).dispatchAttach(or(isNull(), isA<Bundle>()))
   }
 
   /**
@@ -82,6 +82,6 @@ object InteractorHelper {
    */
   @JvmStatic
   open fun verifyDetached(interactor: Interactor<*, *>) {
-    verify(interactor).dispatchDetachInternal()
+    verify(interactor).dispatchDetach()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/PresenterHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/PresenterHelper.kt
@@ -24,7 +24,7 @@ object PresenterHelper {
    */
   @JvmStatic
   open fun load(presenter: Presenter) {
-    presenter.dispatchLoadInternal()
+    presenter.dispatchLoad()
   }
 
   /**
@@ -34,6 +34,6 @@ object PresenterHelper {
    */
   @JvmStatic
   open fun unload(presenter: Presenter) {
-    presenter.dispatchUnloadInternal()
+    presenter.dispatchUnload()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RouterHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RouterHelper.kt
@@ -15,15 +15,15 @@
  */
 package com.uber.rib.core
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import org.mockito.AdditionalMatchers.or
 import org.mockito.InOrder
-import org.mockito.Matchers.anyString
-import org.mockito.Matchers.eq
-import org.mockito.Matchers.isA
-import org.mockito.Matchers.isNull
-import org.mockito.Mockito.never
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.mockito.verification.VerificationMode
 
 /** The helper to test [Router].  */
@@ -36,7 +36,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun <R : Router<*>> attach(router: R) {
-    router.dispatchAttachInternal(null)
+    router.dispatchAttach(null)
   }
 
   /**
@@ -46,7 +46,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun detach(router: Router<*>) {
-    router.dispatchDetachInternal()
+    router.dispatchDetach()
   }
 
   /**
@@ -56,7 +56,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyAttached(router: Router<*>) {
-    verify(router).dispatchAttachInternal(or(isNull(), isA(Bundle::class.java)), anyString())
+    verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
   /**
@@ -67,7 +67,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyAttached(router: Router<*>, times: Int) {
-    verify(router, times(times)).dispatchAttachInternal(or(isNull(), isA(Bundle::class.java)), anyString())
+    verify(router, times(times)).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
   /**
@@ -78,7 +78,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyAttached(order: InOrder, router: Router<*>) {
-    order.verify(router).dispatchAttachInternal(or(isNull(Bundle::class.java), isA(Bundle::class.java)), anyString())
+    order.verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
   /**
@@ -89,7 +89,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyAttached(router: Router<*>, tag: String) {
-    verify(router).dispatchAttachInternal(or(isNull(Bundle::class.java), isA(Bundle::class.java)), eq(tag))
+    verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), eq(tag))
   }
 
   /**
@@ -100,7 +100,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyAttached(router: Router<*>, mode: VerificationMode) {
-    verify(router, mode).dispatchAttachInternal(or(isNull(Bundle::class.java), isA(Bundle::class.java)), anyString())
+    verify(router, mode).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
   /**
@@ -111,7 +111,7 @@ object RouterHelper {
   @JvmStatic
   open fun verifyNotAttached(router: Router<*>) {
     verify(router, never())
-      .dispatchAttachInternal(or(isNull(Bundle::class.java), isA(Bundle::class.java)), anyString())
+      .dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
   /**
@@ -121,7 +121,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyDetached(router: Router<*>) {
-    verify(router).dispatchDetachInternal()
+    verify(router).dispatchDetach()
   }
 
   /**
@@ -132,7 +132,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyDetached(order: InOrder, router: Router<*>) {
-    order.verify(router).dispatchDetachInternal()
+    order.verify(router).dispatchDetach()
   }
 
   /**
@@ -143,7 +143,7 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyDetached(router: Router<*>, mode: VerificationMode) {
-    verify(router, mode).dispatchDetachInternal()
+    verify(router, mode).dispatchDetach()
   }
 
   /**
@@ -153,6 +153,6 @@ object RouterHelper {
    */
   @JvmStatic
   open fun verifyNotDetached(router: Router<*>) {
-    verify(router, never()).dispatchDetachInternal()
+    verify(router, never()).dispatchDetach()
   }
 }


### PR DESCRIPTION
This PR contains a collection of more fixes that were needed to integrate Kotlin RIBs that were missed or not caught by japicmp (resolves #412).

The three main changes include:
- Fold telescoping internal & protected methods into singular public method
- Use `mockito-kotlin` for RouterHelper
- Null check the Interactor's router field's delegate which could be null when a mocked object is passed in