### PR TITLE
Warn when detaching a RIB that was never attached

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
@@ -139,7 +139,13 @@ abstract class Router<I : InteractorType> protected constructor(
     )
     if (savedInstanceState != null) {
       val childrenBundles = savedInstanceState?.getBundleExtra(KEY_CHILD_ROUTERS)
-      childrenBundles?.putBundleExtra(childRouter.tag!!, null)
+      val childRouterTag = childRouter.tag
+      if (childRouterTag != null) {
+        childrenBundles?.putBundleExtra(childRouterTag, null)
+      } else {
+        Rib.getConfiguration()
+          .handleNonFatalWarning("A RIB tried to detach a child that was never attached", null)
+      }
     }
     childRouter.dispatchDetach()
     if (isChildRemoved) {


### PR DESCRIPTION
This PR fixes an edge case by logging a warning when a RIB tries to detach a child that was never attached before. In those cases, the childRouter's tag would be null, which we don't want to use as the key in a Bundle.