### PR TITLE
Replace deprecated keyword 'class' to 'AnyObject'

### DIFF
--- a/ios/RIBs/Classes/Builder.swift
+++ b/ios/RIBs/Classes/Builder.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The base builder protocol that all builders should conform to.
-public protocol Buildable: class {}
+public protocol Buildable: AnyObject {}
 
 /// Utility that instantiates a RIB and sets up its internal wirings.
 open class Builder<DependencyType>: Buildable {

--- a/ios/RIBs/Classes/DI/Dependency.swift
+++ b/ios/RIBs/Classes/DI/Dependency.swift
@@ -20,7 +20,7 @@ import Foundation
 ///
 /// Subclasses should define a set of properties that are required by the module from the DI graph. A dependency is
 /// typically provided and satisfied by its immediate parent module.
-public protocol Dependency: class {}
+public protocol Dependency: AnyObject {}
 
 /// The special empty dependency.
 public protocol EmptyDependency: Dependency {}

--- a/ios/RIBs/Classes/Interactor.swift
+++ b/ios/RIBs/Classes/Interactor.swift
@@ -19,7 +19,7 @@ import RxSwift
 import UIKit
 
 /// Protocol defining the activeness of an interactor's scope.
-public protocol InteractorScope: class {
+public protocol InteractorScope: AnyObject {
 
     // The following properties must be declared in the base protocol, since `Router` internally invokes these methods.
     // In order to unit test router with a mock interactor, the mocked interactor first needs to conform to the custom

--- a/ios/RIBs/Classes/Presenter.swift
+++ b/ios/RIBs/Classes/Presenter.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The base protocol for all `Presenter`s.
-public protocol Presentable: class {}
+public protocol Presentable: AnyObject {}
 
 /// The base class of all `Presenter`s. A `Presenter` translates business models into values the corresponding
 /// `ViewController` can consume and display. It also maps UI events to business logic method, invoked to

--- a/ios/RIBs/Classes/Router.swift
+++ b/ios/RIBs/Classes/Router.swift
@@ -24,7 +24,7 @@ public enum RouterLifecycle {
 }
 
 /// The scope of a `Router`, defining various lifecycles of a `Router`.
-public protocol RouterScope: class {
+public protocol RouterScope: AnyObject {
 
     /// An observable that emits values when the router scope reaches its corresponding life-cycle stages. This
     /// observable completes when the router scope is deallocated.

--- a/ios/RIBs/Classes/ViewControllable.swift
+++ b/ios/RIBs/Classes/ViewControllable.swift
@@ -17,7 +17,7 @@
 import UIKit
 
 /// Basic interface between a `Router` and the UIKit `UIViewController`.
-public protocol ViewControllable: class {
+public protocol ViewControllable: AnyObject {
 
     var uiviewController: UIViewController { get }
 }

--- a/ios/RIBs/Classes/Worker/Worker.swift
+++ b/ios/RIBs/Classes/Worker/Worker.swift
@@ -20,7 +20,7 @@ import RxSwift
 ///
 /// `Worker`s are always bound to an `Interactor`. A `Worker` can only start if its bound `Interactor` is active.
 /// It is stopped when its bound interactor is deactivated.
-public protocol Working: class {
+public protocol Working: AnyObject {
 
     /// Starts the `Worker`.
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: Replace deprecated keyword 'class' to 'AnyObject'

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
