### PR TITLE
Bump Kotlin to 1.5.20

### DIFF
--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -21,11 +21,11 @@ def versions = [
         percent: '1.0.0'
     ],
     autodispose: '1.4.0',
-    dagger: "2.28",
+    dagger: "2.34",
     errorProne: '2.3.3',
     gjf: '1.7',
     intellij: "2019.2",
-    kotlin: "1.4.21",
+    kotlin: "1.5.20",
     ktfmt: '0.23',
     ktlint: '0.41.0',
     rave: "2.0.0",

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/AndroidRecordingRx2Observer.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/AndroidRecordingRx2Observer.kt
@@ -60,10 +60,7 @@ open class AndroidRecordingRx2Observer<T : Any> : Observer<T> {
       events.pollFirst(1, TimeUnit.SECONDS)
     } catch (e: InterruptedException) {
       throw RuntimeException(e)
-    }
-    if (event == null) {
-      throw NoSuchElementException("No event found while waiting for " + wanted.simpleName)
-    }
+    } ?: throw NoSuchElementException("No event found while waiting for " + wanted.simpleName)
     assertThat(event).isInstanceOf(wanted)
     return event as E
   }


### PR DESCRIPTION
Update to latest version of Kotlin to unlock ability to use Jetpack Compose RC builds. Required updating Dagger in order to use the latest KotlinX Metadata which Kotlin expects when running `kapt`. Resolves #462