### PR TITLE
Add NEW_TASK_REPLACE RouterNavigator flag

### DIFF
--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
@@ -59,10 +59,16 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
     NEW_TASK,
 
     /**
+     * Clears the previous stack (no back stack) and pushes the state on to the top of the stack.
+     * If the state is already on the top of the stack, it is detached and replaced.
+     */
+    NEW_TASK_REPLACE,
+
+    /**
      * Remove the top state in the stack if it is not empty and then push a new state to the top of
      * the stack.
      */
-    REPLACE_TOP
+    REPLACE_TOP,
   }
 
   /** Pop the current state and rewind to the previous state (if there is a previous state).  */

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
@@ -90,7 +90,7 @@ open class StackRouterNavigator<StateT : RouterNavigatorState>(private val hostR
     val fromState = peekState()
     val currentRouterAndState = peekCurrentRouterAndState()
     if (fromState != null && fromState.stateName() != newState.stateName()) {
-      if (currentRouterAndState != null && currentRouterAndState.router != null) {
+      if (currentRouterAndState?.router != null) {
         detachInternal(currentRouterAndState, newState, true)
       }
     }
@@ -103,7 +103,7 @@ open class StackRouterNavigator<StateT : RouterNavigatorState>(private val hostR
     val newRouterAndState: RouterNavigator.RouterAndState<StateT>
     when (flag) {
       RouterNavigator.Flag.DEFAULT -> {
-        if (fromState != null && fromState.stateName() == newState.stateName()) {
+        if (newStateIsTop) {
           detachInternal(currentRouterAndState, newState, true)
         }
         newRouterAndState = buildNewState(newState, attachTransition, detachTransition)
@@ -143,6 +143,12 @@ open class StackRouterNavigator<StateT : RouterNavigatorState>(private val hostR
         navigationStack.clear()
         navigationStack.push(currentRouterAndState)
       } else {
+        detachAll()
+        newRouterAndState = buildNewState(newState, attachTransition, detachTransition)
+        attachInternal(currentRouterAndState, newRouterAndState, true)
+        navigationStack.push(newRouterAndState)
+      }
+      RouterNavigator.Flag.NEW_TASK_REPLACE -> {
         detachAll()
         newRouterAndState = buildNewState(newState, attachTransition, detachTransition)
         attachInternal(currentRouterAndState, newRouterAndState, true)

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
@@ -485,10 +485,10 @@ class StackRouterNavigatorTest {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
     routerNavigator.pushState(
-            TestState.STATE_3,
-            RouterNavigator.Flag.NEW_TASK_REPLACE,
-            attachTransition3,
-            detachTransition3
+      TestState.STATE_3,
+      RouterNavigator.Flag.NEW_TASK_REPLACE,
+      attachTransition3,
+      detachTransition3
     )
     verify(detachTransition2).willDetachFromHost(router2, TestState.STATE_2, null, false)
     Truth.assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_3)
@@ -500,10 +500,10 @@ class StackRouterNavigatorTest {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
     routerNavigator.pushState(
-            TestState.STATE_2,
-            RouterNavigator.Flag.NEW_TASK_REPLACE,
-            attachTransition3,
-            detachTransition3
+      TestState.STATE_2,
+      RouterNavigator.Flag.NEW_TASK_REPLACE,
+      attachTransition3,
+      detachTransition3
     )
     verify(detachTransition2).willDetachFromHost(router2, TestState.STATE_2, null, false)
     Truth.assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_2)

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
@@ -481,6 +481,36 @@ class StackRouterNavigatorTest {
   }
 
   @Test
+  fun pushNewTaskReplace_detachesCurrentAndClearsCurrentStack_andShouldPushToTopOfStack() {
+    routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
+    routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
+    routerNavigator.pushState(
+            TestState.STATE_3,
+            RouterNavigator.Flag.NEW_TASK_REPLACE,
+            attachTransition3,
+            detachTransition3
+    )
+    verify(detachTransition2).willDetachFromHost(router2, TestState.STATE_2, null, false)
+    Truth.assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_3)
+    Truth.assertThat(routerNavigator.size()).isEqualTo(1)
+  }
+
+  @Test
+  fun pushNewTaskReplace_whenCurrentTopIsNewState_detachesAllAndPushesToTopOfStack() {
+    routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
+    routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)
+    routerNavigator.pushState(
+            TestState.STATE_2,
+            RouterNavigator.Flag.NEW_TASK_REPLACE,
+            attachTransition3,
+            detachTransition3
+    )
+    verify(detachTransition2).willDetachFromHost(router2, TestState.STATE_2, null, false)
+    Truth.assertThat(routerNavigator.peekState()).isEqualTo(TestState.STATE_2)
+    Truth.assertThat(routerNavigator.size()).isEqualTo(1)
+  }
+
+  @Test
   fun pushReplaceTop_removeExistingTopOfStack_andShouldPushNewStateToTopOfStack() {
     routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
     routerNavigator.pushState(TestState.STATE_2, attachTransition2, detachTransition2)


### PR DESCRIPTION
This flag is similar to the NEW_TASK flag, but it always detaches all existing routers and attaches the new one.

Currently, the DEFAULT flag is the only available flag that detaches the top router if `newStateIsTop` is true. `NEW_TASK_REPLACE` combines this property of `DEFAULT` with the behavior of `NEW_TASK`.

This allows pushing a state with the guarantee that all routers in the stack will be cleared, and that the existing router will be detached.