### PR TITLE
Added RIB subclasses to support Compose

### DIFF
--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -18,6 +18,7 @@ def versions = [
     androidx: [
         annotations: '1.1.0',
         appcompat: '1.3.0',
+        compose: '1.0.2',
         percent: '1.0.0'
     ],
     autodispose: '1.4.0',
@@ -25,7 +26,7 @@ def versions = [
     errorProne: '2.3.3',
     gjf: '1.7',
     intellij: "2019.2",
-    kotlin: "1.4.21",
+    kotlin: "1.5.21",
     ktfmt: '0.23',
     ktlint: '0.41.0',
     rave: "2.0.0",
@@ -76,8 +77,19 @@ def build = [
 ]
 
 def androidx = [
+    activity: "androidx.activity:activity:1.3.0-alpha08",
+    activityCompose: "androidx.activity:activity-compose:1.3.0-beta02",
+    activityKtx: "androidx.activity:activity-ktx:1.3.0-beta02",
     annotations: "androidx.annotation:annotation:${versions.androidx.annotations}",
     appcompat: "androidx.appcompat:appcompat:${versions.androidx.appcompat}",
+    composeAnimation: "androidx.compose.animation:animation:${versions.androidx.compose}",
+    composeFoundation: "androidx.compose.foundation:foundation:${versions.androidx.compose}",
+    composeMaterial: "androidx.compose.material:material:${versions.androidx.compose}",
+    composeNavigation: "androidx.navigation:navigation-compose:2.4.0-alpha03",
+    composeRuntimeRxJava2: "androidx.compose.runtime:runtime-rxjava2:${versions.androidx.compose}",
+    composeUi: "androidx.compose.ui:ui:${versions.androidx.compose}",
+    composeUiTooling: "androidx.compose.ui:ui-tooling:${versions.androidx.compose}",
+    composeViewModel: "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha05",
     percent: "androidx.percentlayout:percentlayout:${versions.androidx.percent}"
 ]
 

--- a/android/gradle/japicmp.gradle
+++ b/android/gradle/japicmp.gradle
@@ -84,7 +84,7 @@ def createJapicmpTask(Project project, String baselineJar, String outputJar) {
 
 allprojects { project ->
     afterEvaluate {
-        if (project.path.startsWith(':libraries:')) {
+        if (project.path.startsWith(':libraries:') && !project.path.startsWith(':libraries:rib-android-compose')) {
             String baselineArtifact = baselineArtifact(project)
             String baselineJar = baselineArtifact.endsWith('.aar')
                     ? "${unpackAarDir(project)}/classes.jar"

--- a/android/libraries/rib-android-compose/build.gradle
+++ b/android/libraries/rib-android-compose/build.gradle
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: "com.vanniktech.maven.publish"
+
+android {
+    compileSdkVersion deps.build.compileSdkVersion
+    buildToolsVersion deps.build.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion deps.build.minSdkVersion
+        targetSdkVersion deps.build.targetSdkVersion
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion deps.versions.androidx.compose
+    }
+
+    compileOptions {
+        sourceCompatibility deps.build.javaVersion
+        targetCompatibility deps.build.javaVersion
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    api project(":libraries:rib-android")
+    implementation deps.androidx.composeFoundation
+    implementation deps.androidx.composeUi
+    testImplementation deps.external.roboelectricBase
+    testImplementation deps.test.mockitoKotlin
+    testImplementation project(":libraries:rib-test")
+}

--- a/android/libraries/rib-android-compose/gradle.properties
+++ b/android/libraries/rib-android-compose/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2017. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=RIBs (Android Compose)
+POM_ARTIFACT_ID=rib-android-compose
+POM_PACKAGING=android

--- a/android/libraries/rib-android-compose/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-android-compose/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.uber.rib.android.compose"/>

--- a/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/BasicComposeRouter.kt
+++ b/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/BasicComposeRouter.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+open class BasicComposeRouter<I : BasicInteractor<*, *>>(
+  val presenter: ComposePresenter,
+  interactor: I
+) : BasicRouter<I>(interactor)

--- a/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/ComposePresenter.kt
+++ b/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/ComposePresenter.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import androidx.compose.runtime.Composable
+
+abstract class ComposePresenter : Presenter() {
+  abstract val composable: @Composable () -> Unit
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,6 @@
 include ':libraries:rib-test'
 include ':libraries:rib-android'
+include ':libraries:rib-android-compose'
 include ':libraries:rib-android-core'
 include ':libraries:rib-base'
 include ':libraries:rib-compiler-app'


### PR DESCRIPTION
Adds Router & Presenter subclasses which enable Compose support in RIBs.

The Compose presenter can be used by DI or an interactor to bind data & event streams to composables. The Compose router enforces usage of a Compose presenter so that a RIB's composable content can be exposed and attached to it's parent RIB's composable slot. 