### PR TITLE
In compose sample: let child ribs populate their own views, taking the job away from parent router

### DIFF
--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootRouter.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootRouter.kt
@@ -38,14 +38,12 @@ class RootRouter(
     if (mainRouter == null) {
       mainRouter = scope.mainScope(view).router().also {
         attachChild(it)
-        this@RootRouter.view.addView(it.view)
       }
     }
   }
 
   private fun detachMain() {
     mainRouter?.let {
-      this@RootRouter.view.removeView(it.view)
       detachChild(it)
     }
   }

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
@@ -17,6 +17,7 @@ package com.uber.rib.compose.root.main
 
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.savedstate.ViewTreeSavedStateRegistryOwner
@@ -33,9 +34,10 @@ import motif.Expose
 interface MainScope {
   fun router(): MainRouter
 
-  fun loggedOutScope(parentViewGroup: ViewGroup): LoggedOutScope
+  fun loggedOutScope(slot: MutableState<(@Composable () -> Unit)>): LoggedOutScope
 
-  fun loggedInScope(parentViewGroup: ViewGroup, authInfo: AuthInfo): LoggedInScope
+  fun loggedInScope(slot: MutableState<(@Composable () -> Unit)>, authInfo: AuthInfo):
+    LoggedInScope
 
   @motif.Objects
   abstract class Objects {
@@ -52,18 +54,15 @@ interface MainScope {
       return object : ComposePresenter() {
         override val composable = @Composable {
           MainView(childContent)
-//          CustomClientProvider(
-//              analyticsClient = analyticsClient,
-//              experimentClient = experimentClient,
-//              loggerClient = loggerClient
-//          ) {
-//
-//          }
         }
       }
     }
 
-    fun view(parentViewGroup: ViewGroup, activity: RibActivity, presenter: ComposePresenter): ComposeView {
+    fun view(
+      parentViewGroup: ViewGroup,
+      activity: RibActivity,
+      presenter: ComposePresenter
+    ): ComposeView {
       return ComposeView(parentViewGroup.context).apply {
         ViewTreeLifecycleOwner.set(this, activity)
         ViewTreeSavedStateRegistryOwner.set(this, activity)

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainView.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainView.kt
@@ -15,7 +15,6 @@
  */
 package com.uber.rib.compose.root.main
 
-import android.widget.FrameLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,8 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import com.uber.rib.compose.R
 
 @Composable
 fun MainView(childContent: MainRouter.ChildContent) {
@@ -52,19 +49,7 @@ fun MainView(childContent: MainRouter.ChildContent) {
         .padding(4.dp)
         .background(Color.Yellow)
     ) {
-      if (childContent.fullScreenContent != null) {
-        childContent.fullScreenContent?.invoke()
-      } else {
-        AndroidView(
-          modifier = Modifier.fillMaxSize(), // Occupy the max size in the Compose UI tree
-          factory = { context ->
-            FrameLayout(context).apply {
-              id = R.id.login_logout_container
-              setBackgroundColor(android.graphics.Color.DKGRAY)
-            }
-          }
-        )
-      }
+      childContent.fullScreenSlot.value.invoke()
     }
   }
 }

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/LoggedInScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/LoggedInScope.kt
@@ -16,6 +16,7 @@
 package com.uber.rib.compose.root.main.logged_in
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import com.uber.rib.compose.root.main.AuthInfo
 import com.uber.rib.compose.root.main.logged_in.off_game.OffGameInteractor
 import com.uber.rib.compose.root.main.logged_in.off_game.OffGameScope
@@ -29,9 +30,9 @@ import motif.Expose
 interface LoggedInScope {
   fun router(): LoggedInRouter
 
-  fun offGameScope(authInfo: AuthInfo): OffGameScope
+  fun offGameScope(slot: MutableState<(@Composable (() -> Unit))>, authInfo: AuthInfo): OffGameScope
 
-  fun ticTacToeScope(authInfo: AuthInfo): TicTacToeScope
+  fun ticTacToeScope(slot: MutableState<(@Composable (() -> Unit))>, authInfo: AuthInfo): TicTacToeScope
 
   @motif.Objects
   abstract class Objects {
@@ -41,7 +42,10 @@ interface LoggedInScope {
 
     abstract fun childContent(): LoggedInRouter.ChildContent
 
-    fun presenter(eventStream: EventStream<LoggedInEvent>, childContent: LoggedInRouter.ChildContent): ComposePresenter {
+    fun presenter(
+      eventStream: EventStream<LoggedInEvent>,
+      childContent: LoggedInRouter.ChildContent
+    ): ComposePresenter {
       return object : ComposePresenter() {
         override val composable = @Composable {
           LoggedInView(eventStream, childContent)

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/LoggedInView.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/LoggedInView.kt
@@ -55,12 +55,14 @@ fun LoggedInView(
         .padding(4.dp)
         .background(Color.LightGray)
     ) {
-      childContent.fullScreenContent?.invoke()
+      childContent.fullScreenSlot.value.invoke()
     }
     CustomButton(
       analyticsId = "8a570808-07a4",
       onClick = { eventStream.notify(LoggedInEvent.LogOutClick) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(16.dp)
     ) {
       Text(text = "LOGOUT")
     }

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/off_game/OffGameRouter.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/off_game/OffGameRouter.kt
@@ -15,10 +15,13 @@
  */
 package com.uber.rib.compose.root.main.logged_in.off_game
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import com.uber.rib.core.BasicComposeRouter
 import com.uber.rib.core.ComposePresenter
 
 class OffGameRouter(
   presenter: ComposePresenter,
-  interactor: OffGameInteractor
-) : BasicComposeRouter<OffGameInteractor>(presenter, interactor)
+  interactor: OffGameInteractor,
+  slot: MutableState<(@Composable () -> Unit)>,
+) : BasicComposeRouter<OffGameInteractor>(presenter, interactor, slot)

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/tic_tac_toe/TicTacToeRouter.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_in/tic_tac_toe/TicTacToeRouter.kt
@@ -15,10 +15,13 @@
  */
 package com.uber.rib.compose.root.main.logged_in.tic_tac_toe
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import com.uber.rib.core.BasicComposeRouter
 import com.uber.rib.core.ComposePresenter
 
 class TicTacToeRouter(
   presenter: ComposePresenter,
-  interactor: TicTacToeInteractor
-) : BasicComposeRouter<TicTacToeInteractor>(presenter, interactor)
+  interactor: TicTacToeInteractor,
+  slot: MutableState<(@Composable () -> Unit)>,
+) : BasicComposeRouter<TicTacToeInteractor>(presenter, interactor, slot)

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutRouter.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutRouter.kt
@@ -15,10 +15,13 @@
  */
 package com.uber.rib.compose.root.main.logged_out
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import com.uber.rib.core.BasicComposeRouter
 import com.uber.rib.core.ComposePresenter
 
 class LoggedOutRouter(
   presenter: ComposePresenter,
-  interactor: LoggedOutInteractor
-) : BasicComposeRouter<LoggedOutInteractor>(presenter, interactor)
+  interactor: LoggedOutInteractor,
+  slot: MutableState<(@Composable () -> Unit)>
+) : BasicComposeRouter<LoggedOutInteractor>(presenter, interactor, slot)

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutScope.kt
@@ -31,10 +31,16 @@ interface LoggedOutScope {
 
     abstract fun interactor(): LoggedOutInteractor
 
-    fun presenter(stateStream: StateStream<LoggedOutViewModel>, eventStream: EventStream<LoggedOutEvent>): ComposePresenter {
+    fun presenter(
+      stateStream: StateStream<LoggedOutViewModel>,
+      eventStream: EventStream<LoggedOutEvent>
+    ): ComposePresenter {
       return object : ComposePresenter() {
         override val composable = @Composable {
-          LoggedOutView(stateStream.observe().subscribeAsState(initial = stateStream.current()), eventStream)
+          LoggedOutView(
+            stateStream.observe().subscribeAsState(initial = stateStream.current()),
+            eventStream
+          )
         }
       }
     }

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutView.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/logged_out/LoggedOutView.kt
@@ -38,7 +38,9 @@ import com.uber.rib.compose.util.EventStream
 @Composable
 fun LoggedOutView(viewModel: State<LoggedOutViewModel>, eventStream: EventStream<LoggedOutEvent>) {
   Column(
-    modifier = Modifier.fillMaxSize().padding(16.dp),
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(16.dp, alignment = Alignment.Bottom),
   ) {
     TextField(
@@ -54,7 +56,10 @@ fun LoggedOutView(viewModel: State<LoggedOutViewModel>, eventStream: EventStream
       modifier = Modifier.fillMaxWidth()
     )
     Button(
-      colors = ButtonDefaults.buttonColors(backgroundColor = Color.Black, contentColor = Color.White),
+      colors = ButtonDefaults.buttonColors(
+        backgroundColor = Color.Black,
+        contentColor = Color.White
+      ),
       onClick = { eventStream.notify(LoggedOutEvent.LogInClick) },
       modifier = Modifier.fillMaxWidth()
     ) {

--- a/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/BasicComposeRouter.kt
+++ b/android/libraries/rib-android-compose/src/main/kotlin/com/uber/rib/core/BasicComposeRouter.kt
@@ -15,7 +15,21 @@
  */
 package com.uber.rib.core
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+
 open class BasicComposeRouter<I : BasicInteractor<*, *>>(
   val presenter: ComposePresenter,
-  interactor: I
-) : BasicRouter<I>(interactor)
+  interactor: I,
+  val slot: MutableState<(@Composable () -> Unit)>
+) : BasicRouter<I>(interactor) {
+  override fun willAttach() {
+    slot.value = presenter.composable
+    super.willAttach()
+  }
+
+  override fun willDetach() {
+    slot.value = {}
+    super.willDetach()
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Code organization optimization: making attaching/detaching view the job of the child router and move the logic up to `BasicComposeRouter`. 
Parent Routers do not operate directly on children's views anymore. 


<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
