### PR TITLE
Fix cocoapods compatibility issue in ios TicTacToe tutorial

### DIFF
--- a/ios/tutorials/tutorial1/Podfile
+++ b/ios/tutorials/tutorial1/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end

--- a/ios/tutorials/tutorial2/Podfile
+++ b/ios/tutorials/tutorial2/Podfile
@@ -6,7 +6,7 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end
 
 target 'TicTacToeTests' do

--- a/ios/tutorials/tutorial3-completed/Podfile
+++ b/ios/tutorials/tutorial3-completed/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end

--- a/ios/tutorials/tutorial3/Podfile
+++ b/ios/tutorials/tutorial3/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end

--- a/ios/tutorials/tutorial4-completed/Podfile
+++ b/ios/tutorials/tutorial4-completed/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end

--- a/ios/tutorials/tutorial4/Podfile
+++ b/ios/tutorials/tutorial4/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.0.0'
 end


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Because of cocoapods compatibility issue in ios TicTacToe tutorial (RIBs and RxCocoa), pods libs cannot be installed and cannot generate `xcworkspace` file.
To fix this issue, I bump RxCocoa to 6.0.0 in Podfile. After changed the version, Installing is successful and TicTacToe is also 
works fine.

- Before

<img width="568" alt="스크린샷 2022-01-11 오전 1 28 23" src="https://user-images.githubusercontent.com/31857308/148803606-cb6abb45-f092-4ae3-ab03-e9bd6471dc48.png">

- After

<img width="566" alt="스크린샷 2022-01-11 오전 1 35 03" src="https://user-images.githubusercontent.com/31857308/148803570-a4a2d72b-25a1-4fa6-be9d-661a99df133b.png">




<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
