### PR TITLE
Fix typo in Interactor comments (callend -> called)

### DIFF
--- a/ios/RIBs/Classes/Interactor.swift
+++ b/ios/RIBs/Classes/Interactor.swift
@@ -126,7 +126,7 @@ open class Interactor: Interactable {
         isActiveSubject.onNext(false)
     }
 
-    /// Callend when the `Interactor` will resign the active state.
+    /// Called when the `Interactor` will resign the active state.
     ///
     /// This method is driven by the detachment of this interactor's owner router. Subclasses should override this
     /// method to cleanup any resources and states of the `Interactor`. The default implementation does nothing.


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: This pull request contains a change to Interactor class comments correcting a minor typo. I changed the `callend` to `called`.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: Interactor class comments

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
