### PR TITLE
Don't use default interface method bytecode optimization for target 1.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -151,7 +151,6 @@ subprojects {
 
         if (isKotlinLibrary) {
             def extraCompilerArgs = [
-                    "-Xjvm-default=all"
             ]
             if (project.name in moduleFriends.keySet()) {
                 def friendName = moduleFriends[project.name]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -151,6 +151,8 @@ subprojects {
 
         if (isKotlinLibrary) {
             def extraCompilerArgs = [
+                    // See https://github.com/bazelbuild/bazel/issues/15144
+                    "-Xjvm-default=enable"
             ]
             if (project.name in moduleFriends.keySet()) {
                 def friendName = moduleFriends[project.name]

--- a/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/ActivityDelegate.kt
+++ b/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/ActivityDelegate.kt
@@ -27,24 +27,31 @@ import androidx.annotation.IntRange
  */
 interface ActivityDelegate {
   /** @see [Activity.onCreate] */
+  @JvmDefault
   fun onCreate(savedInstanceState: Bundle?) {}
 
   /** @see [Activity.onStart] */
+  @JvmDefault
   fun onStart() {}
 
   /** @see [Activity.onResume] */
+  @JvmDefault
   fun onResume() {}
 
   /** @see [Activity.onPause] */
+  @JvmDefault
   fun onPause() {}
 
   /** @see [Activity.onStop] */
+  @JvmDefault
   fun onStop() {}
 
   /** @see [Activity.onDestroy] */
+  @JvmDefault
   fun onDestroy() {}
 
   /** @see [Activity.onActivityResult] */
+  @JvmDefault
   fun onActivityResult(
     activity: Activity,
     requestCode: Int,
@@ -53,6 +60,7 @@ interface ActivityDelegate {
   ) {}
 
   /** @see [Activity.onRequestPermissionsResult] */
+  @JvmDefault
   fun onRequestPermissionsResult(
     activity: Activity,
     @IntRange(from = 0, to = 255) requestCode: Int,

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RxActivityEvents.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RxActivityEvents.kt
@@ -32,6 +32,7 @@ interface RxActivityEvents {
    * @param clazz The [ActivityLifecycleEvent] subclass you want.
    * @return an observable of this activity's lifecycle events.
    */
+  @JvmDefault
   fun <T : ActivityLifecycleEvent> lifecycle(clazz: Class<T>): Observable<T> {
     return lifecycle()
       .filter { activityEvent -> clazz.isAssignableFrom(activityEvent.javaClass) }
@@ -43,6 +44,7 @@ interface RxActivityEvents {
    * @param clazz The [ActivityCallbackEvent] subclass you want.
    * @return an observable of this activity's callbacks events.
    */
+  @JvmDefault
   fun <T : ActivityCallbackEvent> callbacks(clazz: Class<T>): Observable<T> {
     return callbacks()
       .filter { activityEvent -> clazz.isAssignableFrom(activityEvent.javaClass) }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
@@ -27,8 +27,10 @@ interface Worker {
    *
    * @param lifecycle The lifecycle of the worker to use for subscriptions.
    */
+  @JvmDefault
   fun onStart(lifecycle: WorkerScopeProvider) {}
 
   /** Called when the worker is stopped.  */
+  @JvmDefault
   fun onStop() {}
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
@@ -19,7 +19,6 @@ package com.uber.rib.core
 interface RouterNavigatorState {
 
   /** @return identifier for a [StackRouterNavigator] state. */
-  @JvmDefault
   fun stateName(): String {
     return if (this.javaClass.isEnum) {
       (this as Enum<*>).name

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
@@ -19,6 +19,7 @@ package com.uber.rib.core
 interface RouterNavigatorState {
 
   /** @return identifier for a [StackRouterNavigator] state. */
+  @JvmDefault
   fun stateName(): String {
     return if (this.javaClass.isEnum) {
       (this as Enum<*>).name


### PR DESCRIPTION
**Description**:
Generating default methods in interfaces (with lambda expression in their body compiled as bridge methods) for the Java 8 target result in bytecode that fails to be de-sugared by Bazel. This will be presumably fixed in future version of bazel, for the time being, disable this optimization and rely on the bytecode generation used in older kotlin compiler, it relies on generating a separate static class and works around the issue with lambda/bridge.

More technical info :
- https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/
- http://www.angelikalanger.com/GenericsFAQ/FAQSections/TechnicalDetails.html#FAQ102

