### PR TITLE
Fix unexpected dependency version of CocoaPods

### DIFF
--- a/RIBs.podspec
+++ b/RIBs.podspec
@@ -11,6 +11,6 @@ RIBs is the cross-platform architecture behind many mobile apps at Uber. This ar
   s.source           = { :git => 'https://github.com/uber/RIBs.git', :tag => 'v' + s.version.to_s }
   s.ios.deployment_target = '9.0'
   s.source_files = 'ios/RIBs/Classes/**/*'
-  s.dependency 'RxSwift', '~> 6.0.0'
-  s.dependency 'RxRelay', '~> 6.0.0'
+  s.dependency 'RxSwift', '~> 6.0'
+  s.dependency 'RxRelay', '~> 6.0'
 end


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
I'm found a bug while installing RIBs using CocoaPods.

I have confirmed that the results are different from when I used a different package manager(such as SwiftPM, Carthage).

All installation methods are looking at the branch "main".

**SwiftPM**:
![image](https://user-images.githubusercontent.com/11539551/169496467-5669d692-fab7-4b6f-95e1-c43ae465ca3a.png)

**Carthage**:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/11539551/169496620-65c49d10-a029-44d9-95c3-d2a47b9e15ca.png">

**CocoaPods**:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/11539551/169496726-f76f0564-8433-460d-9d28-4c0ad1630173.png">

This issue occurs because the "CocoaPods" dependency requirement version notation is different.
https://guides.cocoapods.org/syntax/podspec.html#dependency

SwiftPM:
https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency

Carthage:
https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile

I think CocoaPods are a bug, so I open a Pull Request.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
