### PR TITLE
Adding support for relaying window focus events from RibActivity

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -35,6 +35,7 @@ import com.uber.rib.core.lifecycle.ActivityCallbackEvent.Companion.createOnActiv
 import com.uber.rib.core.lifecycle.ActivityCallbackEvent.Companion.createOnSaveInstanceStateEvent
 import com.uber.rib.core.lifecycle.ActivityCallbackEvent.Companion.createPictureInPictureMode
 import com.uber.rib.core.lifecycle.ActivityCallbackEvent.Companion.createTrimMemoryEvent
+import com.uber.rib.core.lifecycle.ActivityCallbackEvent.Companion.createWindowFocusEvent
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.create
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.createOnCreateEvent
@@ -178,6 +179,11 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   override fun onUserLeaveHint() {
     lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.USER_LEAVING))
     super.onUserLeaveHint()
+  }
+
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    super.onWindowFocusChanged(hasFocus)
+    callbacksRelay.accept(createWindowFocusEvent(hasFocus))
   }
 
   /**

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityCallbackEvent.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityCallbackEvent.kt
@@ -26,12 +26,15 @@ open class ActivityCallbackEvent private constructor(
 
   /** Types of activity events that can occur.  */
   enum class Type : ActivityEvent.BaseType {
-    LOW_MEMORY, ACTIVITY_RESULT, SAVE_INSTANCE_STATE, TRIM_MEMORY, PICTURE_IN_PICTURE_MODE, NEW_INTENT
+    LOW_MEMORY, ACTIVITY_RESULT, SAVE_INSTANCE_STATE, TRIM_MEMORY, PICTURE_IN_PICTURE_MODE, NEW_INTENT, WINDOW_FOCUS
   }
 
   /** An [ActivityCallbackEvent] that represents [Activity.onNewIntent] event  */
   open class NewIntent(open val intent: Intent) : ActivityCallbackEvent(Type.NEW_INTENT)
   open class PictureInPictureMode(open val isInPictureInPictureMode: Boolean) : ActivityCallbackEvent(Type.PICTURE_IN_PICTURE_MODE)
+
+  /** An [ActivityCallbackEvent] that represents [Activity.onWindowFocusChanged] event */
+  open class WindowFocus(open val hasFocus: Boolean) : ActivityCallbackEvent(Type.WINDOW_FOCUS)
 
   /** An [ActivityCallbackEvent] that represents [Activity.onTrimMemory] event  */
   open class TrimMemory internal constructor(open val trimMemoryType: Int) : ActivityCallbackEvent(Type.TRIM_MEMORY)
@@ -124,6 +127,17 @@ open class ActivityCallbackEvent private constructor(
     @JvmStatic
     fun createNewIntent(intent: Intent): NewIntent {
       return NewIntent(intent)
+    }
+
+    /**
+     * Creates an event for onWindowFocusChanged
+     *
+     * @param hasFocus determines whether the window of this activity got focus or not
+     * @return the newly created [WindowFocus]
+     */
+    @JvmStatic
+    fun createWindowFocusEvent(hasFocus: Boolean): WindowFocus {
+      return WindowFocus(hasFocus)
     }
   }
 }

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
@@ -170,6 +170,24 @@ class RibActivityTest {
   }
 
   @Test
+  fun rxActivity_shouldCallback_onWindowFocusChanged() {
+    val activityController = Robolectric.buildActivity(EmptyActivity::class.java)
+    val activity: EmptyActivity = activityController.setup().get()
+    val testSub = TestObserver<ActivityCallbackEvent.WindowFocus>()
+    activity.callbacks(ActivityCallbackEvent.WindowFocus::class.java).subscribe(testSub)
+    activity.onWindowFocusChanged(true)
+    activity.onWindowFocusChanged(false)
+    testSub.assertValueCount(2)
+    val receivedEvent1 = testSub.values()[0]
+    assertThat(receivedEvent1.type).isEqualTo(ActivityCallbackEvent.Type.WINDOW_FOCUS)
+    assertThat(receivedEvent1.hasFocus).isTrue()
+    val receivedEvent2 = testSub.values()[1]
+    assertThat(receivedEvent2.type).isEqualTo(ActivityCallbackEvent.Type.WINDOW_FOCUS)
+    assertThat(receivedEvent2.hasFocus).isFalse()
+
+  }
+
+  @Test
   fun getController() {
     val activity: RibActivity = Robolectric.setupActivity(EmptyActivity::class.java)
     assertThat(activity.interactor).isNotNull()

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
@@ -184,7 +184,6 @@ class RibActivityTest {
     val receivedEvent2 = testSub.values()[1]
     assertThat(receivedEvent2.type).isEqualTo(ActivityCallbackEvent.Type.WINDOW_FOCUS)
     assertThat(receivedEvent2.hasFocus).isFalse()
-
   }
 
   @Test


### PR DESCRIPTION
**Description**:
This PR adds support for the callbacks relay to include window focus change events from an activity. 

**Related issue(s)**:
None

**Unit tests**:
RibActivityTest / rxActivity_shouldCallback_onWindowFocusChanged
