### PR TITLE
Remove open presenter and add JvmField on BasicInteractor

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/BasicInteractor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/BasicInteractor.kt
@@ -22,5 +22,5 @@ package com.uber.rib.core
  * @param <R> the type of [Router].
  */
 abstract class BasicInteractor<P : Any, R : Router<*>> protected constructor(
- @JvmField protected var presenter: P
+  @JvmField protected var presenter: P
 ) : Interactor<P, R>(presenter)

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/BasicInteractor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/BasicInteractor.kt
@@ -22,5 +22,5 @@ package com.uber.rib.core
  * @param <R> the type of [Router].
  */
 abstract class BasicInteractor<P : Any, R : Router<*>> protected constructor(
-  protected open var presenter: P
+ @JvmField protected var presenter: P
 ) : Interactor<P, R>(presenter)


### PR DESCRIPTION
Removing previous change to the presenter field in favor of making it a closed JvmField to maintain compatibility.
In 0.13.1 we tried an api breaking change to account for kotlin 1.7 requirements, however that appears to have a large number of unaccounted for usages. This new approach removes the open keyword and reads the JvmField. The behavior is essentially unchanged, since the open was a no-op before and now Kotlin compilation breaks to ensure correctness.

This is still a hack for java compatibility, and may eventually be removed in favor of referencing via getPresenter().

Testing:
Made internal build for use with Uber repo, tested build of Rider, Driver, and Eats app against this update. Java and Kotlin code making direct reference to the field was successfully built.

