### PR TITLE
Fix: podspec and tutorial1 Podfile version updated

### DIFF
--- a/RIBs.podspec
+++ b/RIBs.podspec
@@ -11,6 +11,6 @@ RIBs is the cross-platform architecture behind many mobile apps at Uber. This ar
   s.source           = { :git => 'https://github.com/uber/RIBs.git', :tag => 'v' + s.version.to_s }
   s.ios.deployment_target = '9.0'
   s.source_files = 'ios/RIBs/Classes/**/*'
-  s.dependency 'RxSwift', '~> 6.0.0'
-  s.dependency 'RxRelay', '~> 6.0.0'
+  s.dependency 'RxSwift', '~> 6.5.0'
+  s.dependency 'RxRelay', '~> 6.5.0'
 end

--- a/ios/tutorials/tutorial1/Podfile
+++ b/ios/tutorials/tutorial1/Podfile
@@ -1,10 +1,14 @@
-platform :ios, '9.0'
-
-use_frameworks!
-inhibit_all_warnings!
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
 
 target 'TicTacToe' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+  inhibit_all_warnings!
+
+  # Pods for TicTacToe
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 5.1'
+  pod 'RxCocoa', '~> 6.5'
+
 end


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Because of the low version of RxSwift and RxRelay in podspec file, pod install gives error. To resolve this issue in tutorial1 project i updated the podspec and Podfile

- Before
![Screenshot 2023-01-03 at 00 01 03](https://user-images.githubusercontent.com/32433476/210277839-1acd592b-19f7-48df-940f-cc06e71d68a8.png)

- After
![Screenshot 2023-01-03 at 00 01 13](https://user-images.githubusercontent.com/32433476/210277832-f4a0225c-305f-45dc-a25d-905500c2f8be.png)


<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
#312 
#389 
#354 
#388 

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
