### PR TITLE
Clear cached `CoroutineScope` instance once its job completes

### DIFF
--- a/android/libraries/rib-coroutines-test/src/test/kotlin/com/uber/rib/core/RibScopesTest.kt
+++ b/android/libraries/rib-coroutines-test/src/test/kotlin/com/uber/rib/core/RibScopesTest.kt
@@ -147,6 +147,24 @@ internal class RibScopesTest {
     assertThat(realScope2).isNotInstanceOf(TestScope::class.java)
   }
 
+  @Test
+  fun testScopeReattaching() {
+    val interactor = object : BasicInteractor<Presenter, Router<*>>(mock()) {}
+    with(interactor) {
+      dispatchAttach(null)
+      with(coroutineScope) {
+        assertThat(isActive).isTrue()
+        dispatchDetach()
+        // after dispatching detach, we expect the same instance captured before to be inactive
+        assertThat(isActive).isFalse()
+      }
+      dispatchAttach(null)
+      // The previous instance of coroutineScope is permanently cancelled,
+      // but ScopeProvider.coroutineScope should now return a new, active instance.
+      assertThat(coroutineScope.isActive).isTrue()
+    }
+  }
+
   private class TestUncaughtExceptionCaptor : CoroutineExceptionHandler {
     var exceptions = mutableListOf<Throwable>()
 


### PR DESCRIPTION
Fixes #535.

<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Fixes `ScopeProvider.coroutineScope` lifecycle to better align with the backing `ScopeProvider` lifecycle behavior.

With this fix, a fresh, non-cancelled instance of `CoroutineScope` is delivered by `ScopeProvider.coroutineScope` every time the previously cached instance  is completed/canceled. Every scope instance is synchronously **cleared from cache** once it is completed/canceled. This is implemented by installing a `CompletionHandler` on the `CoroutineScope` `Job` that **clears the cache when scope is completed**.

This new behavior of clearing the cache upon completion effectively allows for re-launching coroutines on the attach callback when an attach-detach-attach cycle occurs on `ScopeProvider` components with a lifecycle.

Re-launching coroutines upon reattachment is not possible in current implementation (without this fix): a single `CoroutineScope` is cached for the whole life of the instance, and `ScopeProvider.coroutineScope` delivers a stale, cancelled instance  of `CoroutineScope` after reattaching the component (even though `ScopeProvider.requestScope()` delivers a new `Completable`.

To be clear, the correct reattachment behavior is already in place for Rx subscriptions that `autoDispose` by `ScopeProvider`:  they are backed by the `Completable`, which work fine on attach-detach-reattach cycles. This PR makes coroutines behavior consistent with the currently established behavior in RIBs.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #535 

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
