### PR TITLE
Replacing some Behavior/Publish Relay usage in core artifacts with coroutines

### DIFF
--- a/android/libraries/rib-android/build.gradle
+++ b/android/libraries/rib-android/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation deps.androidx.annotations
     implementation deps.androidx.appcompat
     implementation deps.external.guavaAndroid
+    implementation deps.uber.autodisposeCoroutines
+    implementation deps.kotlin.coroutinesAndroid
+    implementation deps.kotlin.coroutinesRx2
     testImplementation deps.external.roboelectricBase
     testImplementation deps.androidx.appcompat
     testImplementation deps.test.mockitoKotlin

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -37,6 +37,7 @@ import com.uber.rib.core.lifecycle.ActivityLifecycleEvent
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.create
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.createOnCreateEvent
 import io.reactivex.CompletableSource
+import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -50,17 +51,17 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   private val callbacksObservable = callbacksFlow.asObservable()
 
   /** @return an observable of this activity's lifecycle events. */
-  override fun lifecycle() = lifecycleObservable
+  override fun lifecycle(): Observable<ActivityLifecycleEvent> = lifecycleObservable
 
   /** @return an observable of this activity's lifecycle events. */
-  override fun callbacks() = callbacksObservable
+  override fun callbacks(): Observable<ActivityCallbackEvent> = callbacksObservable
 
   override fun correspondingEvents(): CorrespondingEventsFunction<ActivityLifecycleEvent> {
     return ACTIVITY_LIFECYCLE
   }
 
-  override fun peekLifecycle(): ActivityLifecycleEvent {
-    return lifecycleFlow.replayCache.last()
+  override fun peekLifecycle(): ActivityLifecycleEvent? {
+    return lifecycleFlow.replayCache.lastOrNull()
   }
 
   override fun requestScope(): CompletableSource {

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -37,7 +37,6 @@ import com.uber.rib.core.lifecycle.ActivityLifecycleEvent
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.create
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.createOnCreateEvent
 import io.reactivex.CompletableSource
-import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -47,16 +46,14 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   private var router: ViewRouter<*, *>? = null
   private val lifecycleFlow = MutableSharedFlow<ActivityLifecycleEvent>(1, 0, BufferOverflow.DROP_OLDEST)
   private val callbacksFlow = MutableSharedFlow<ActivityCallbackEvent>(0, 1, BufferOverflow.DROP_OLDEST)
+  private val lifecycleObservable = lifecycleFlow.asObservable()
+  private val callbacksObservable = callbacksFlow.asObservable()
 
   /** @return an observable of this activity's lifecycle events. */
-  override fun lifecycle(): Observable<ActivityLifecycleEvent> {
-    return lifecycleFlow.asObservable()
-  }
+  override fun lifecycle() = lifecycleObservable
 
   /** @return an observable of this activity's lifecycle events. */
-  override fun callbacks(): Observable<ActivityCallbackEvent> {
-    return callbacksFlow.asObservable()
-  }
+  override fun callbacks() = callbacksObservable
 
   override fun correspondingEvents(): CorrespondingEventsFunction<ActivityLifecycleEvent> {
     return ACTIVITY_LIFECYCLE

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -21,9 +21,6 @@ import android.content.res.Configuration
 import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
-import com.jakewharton.rxrelay2.BehaviorRelay
-import com.jakewharton.rxrelay2.PublishRelay
-import com.jakewharton.rxrelay2.Relay
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
@@ -41,22 +38,24 @@ import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.create
 import com.uber.rib.core.lifecycle.ActivityLifecycleEvent.Companion.createOnCreateEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.rx2.asObservable
 
 /** Base implementation for all VIP [android.app.Activity]s. */
 abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, LifecycleScopeProvider<ActivityLifecycleEvent>, RxActivityEvents {
   private var router: ViewRouter<*, *>? = null
-  private val lifecycleBehaviorRelay = BehaviorRelay.create<ActivityLifecycleEvent>()
-  private val lifecycleRelay: Relay<ActivityLifecycleEvent> = lifecycleBehaviorRelay.toSerialized()
-  private val callbacksRelay = PublishRelay.create<ActivityCallbackEvent>().toSerialized()
+  private val lifecycleFlow = MutableSharedFlow<ActivityLifecycleEvent>(1, 0, BufferOverflow.DROP_OLDEST)
+  private val callbacksFlow = MutableSharedFlow<ActivityCallbackEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
   /** @return an observable of this activity's lifecycle events. */
   override fun lifecycle(): Observable<ActivityLifecycleEvent> {
-    return lifecycleRelay.hide()
+    return lifecycleFlow.asObservable()
   }
 
   /** @return an observable of this activity's lifecycle events. */
   override fun callbacks(): Observable<ActivityCallbackEvent> {
-    return callbacksRelay.hide()
+    return callbacksFlow.asObservable()
   }
 
   override fun correspondingEvents(): CorrespondingEventsFunction<ActivityLifecycleEvent> {
@@ -64,7 +63,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   }
 
   override fun peekLifecycle(): ActivityLifecycleEvent {
-    return lifecycleBehaviorRelay.value!!
+    return lifecycleFlow.replayCache.last()
   }
 
   override fun requestScope(): CompletableSource {
@@ -76,7 +75,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   override fun onCreate(savedInstanceState: android.os.Bundle?) {
     super.onCreate(savedInstanceState)
     val rootViewGroup = findViewById<ViewGroup>(R.id.content)
-    lifecycleRelay.accept(createOnCreateEvent(savedInstanceState))
+    lifecycleFlow.tryEmit(createOnCreateEvent(savedInstanceState))
     val wrappedBundle: Bundle? = if (savedInstanceState != null) Bundle(savedInstanceState) else null
     router = createRouter(rootViewGroup)
     router?.let {
@@ -89,49 +88,49 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   @CallSuper
   override fun onSaveInstanceState(outState: android.os.Bundle) {
     super.onSaveInstanceState(outState)
-    callbacksRelay.accept(createOnSaveInstanceStateEvent(outState))
+    callbacksFlow.tryEmit(createOnSaveInstanceStateEvent(outState))
     router?.saveInstanceStateInternal(Bundle(outState)) ?: throw NullPointerException("Router should not be null")
   }
 
   @CallSuper
   override fun onStart() {
     super.onStart()
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.START))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.START))
   }
 
   @CallSuper
   override fun onResume() {
     super.onResume()
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.RESUME))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.RESUME))
   }
 
   @CallSuper
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
-    callbacksRelay.accept(createNewIntent(intent))
+    callbacksFlow.tryEmit(createNewIntent(intent))
   }
 
   @CallSuper
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
-    callbacksRelay.accept(createOnActivityResultEvent(requestCode, resultCode, data))
+    callbacksFlow.tryEmit(createOnActivityResultEvent(requestCode, resultCode, data))
   }
 
   @CallSuper
   override fun onPause() {
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.PAUSE))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.PAUSE))
     super.onPause()
   }
 
   @CallSuper
   override fun onStop() {
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.STOP))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.STOP))
     super.onStop()
   }
 
   @CallSuper
   override fun onDestroy() {
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.DESTROY))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.DESTROY))
     router?.let {
       it.dispatchDetach()
       RibEvents.getInstance().emitEvent(RibEventType.DETACHED, it, null)
@@ -143,20 +142,20 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   @CallSuper
   override fun onLowMemory() {
     super.onLowMemory()
-    callbacksRelay.accept(create(ActivityCallbackEvent.Type.LOW_MEMORY))
+    callbacksFlow.tryEmit(create(ActivityCallbackEvent.Type.LOW_MEMORY))
   }
 
   @CallSuper
   override fun onTrimMemory(level: Int) {
     super.onTrimMemory(level)
-    callbacksRelay.accept(createTrimMemoryEvent(level))
+    callbacksFlow.tryEmit(createTrimMemoryEvent(level))
   }
 
   override fun onPictureInPictureModeChanged(
     isInPictureInPictureMode: Boolean,
     newConfig: Configuration
   ) {
-    callbacksRelay.accept(
+    callbacksFlow.tryEmit(
       createPictureInPictureMode(isInPictureInPictureMode)
     )
   }
@@ -177,13 +176,15 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
   }
 
   override fun onUserLeaveHint() {
-    lifecycleRelay.accept(create(ActivityLifecycleEvent.Type.USER_LEAVING))
+    lifecycleFlow.tryEmit(create(ActivityLifecycleEvent.Type.USER_LEAVING))
     super.onUserLeaveHint()
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
-    callbacksRelay.accept(createWindowFocusEvent(hasFocus))
+
+    val result = callbacksFlow.tryEmit(createWindowFocusEvent(hasFocus))
+    val s =""
   }
 
   /**

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -182,9 +182,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
-
-    val result = callbacksFlow.tryEmit(createWindowFocusEvent(hasFocus))
-    val s = ""
+    callbacksFlow.tryEmit(createWindowFocusEvent(hasFocus))
   }
 
   /**

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -184,7 +184,7 @@ abstract class RibActivity : CoreAppCompatActivity(), ActivityStarter, Lifecycle
     super.onWindowFocusChanged(hasFocus)
 
     val result = callbacksFlow.tryEmit(createWindowFocusEvent(hasFocus))
-    val s =""
+    val s = ""
   }
 
   /**

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     api deps.uber.autodisposeLifecycle
     implementation deps.apt.javaxInject
 
+    implementation deps.uber.autodisposeCoroutines
+    implementation deps.kotlin.coroutinesAndroid
+    implementation deps.kotlin.coroutinesRx2
+
     compileOnly deps.apt.daggerCompiler
     compileOnly deps.androidx.annotations
     compileOnly deps.apt.androidApi

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation deps.kotlin.coroutinesAndroid
     implementation deps.kotlin.coroutinesRx2
 
+    implementation project(":libraries:rib-coroutines")
+
     compileOnly deps.apt.daggerCompiler
     compileOnly deps.androidx.annotations
     compileOnly deps.apt.androidApi

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -23,7 +23,6 @@ import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.rib.core.lifecycle.InteractorEvent
 import io.reactivex.CompletableSource
-import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -42,6 +41,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   lateinit var injectedPresenter: P
   internal var actualPresenter: P? = null
   private val lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, 0, BufferOverflow.DROP_OLDEST)
+  private val lifecycleObservable = lifecycleFlow.asObservable()
 
   private val routerDelegate = InitOnceProperty<R>()
   /** @return the router for this interactor. */
@@ -55,9 +55,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   }
 
   /** @return an observable of this controller's lifecycle events. */
-  override fun lifecycle(): Observable<InteractorEvent> {
-    return lifecycleFlow.asObservable()
-  }
+  override fun lifecycle() = lifecycleObservable
 
   /** @return true if the controller is attached, false if not. */
   override fun isAttached() = lifecycleFlow.replayCache.last() == InteractorEvent.ACTIVE

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -59,7 +59,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   override fun lifecycle(): Observable<InteractorEvent> = lifecycleObservable
 
   /** @return true if the controller is attached, false if not. */
-  override fun isAttached() = lifecycleFlow.replayCache.last() == InteractorEvent.ACTIVE
+  override fun isAttached() = lifecycleFlow.replayCache.lastOrNull() == InteractorEvent.ACTIVE
 
   /**
    * Called when attached. The presenter will automatically be added when this happens.

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -23,6 +23,7 @@ import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.rib.core.lifecycle.InteractorEvent
 import io.reactivex.CompletableSource
+import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -55,7 +56,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   }
 
   /** @return an observable of this controller's lifecycle events. */
-  override fun lifecycle() = lifecycleObservable
+  override fun lifecycle(): Observable<InteractorEvent> = lifecycleObservable
 
   /** @return true if the controller is attached, false if not. */
   override fun isAttached() = lifecycleFlow.replayCache.last() == InteractorEvent.ACTIVE
@@ -139,7 +140,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   }
 
   override fun peekLifecycle(): InteractorEvent? {
-    return lifecycleFlow.replayCache.last()
+    return lifecycleFlow.replayCache.lastOrNull()
   }
 
   final override fun requestScope(): CompletableSource {

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -17,7 +17,6 @@ package com.uber.rib.core
 
 import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
@@ -25,6 +24,9 @@ import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.rib.core.lifecycle.InteractorEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.rx2.asObservable
 import javax.inject.Inject
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -39,8 +41,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   @Inject
   lateinit var injectedPresenter: P
   internal var actualPresenter: P? = null
-  private val behaviorRelay = BehaviorRelay.create<InteractorEvent>()
-  private val lifecycleRelay = behaviorRelay.toSerialized()
+  private val lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, 0, BufferOverflow.DROP_OLDEST)
 
   private val routerDelegate = InitOnceProperty<R>()
   /** @return the router for this interactor. */
@@ -55,11 +56,11 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
 
   /** @return an observable of this controller's lifecycle events. */
   override fun lifecycle(): Observable<InteractorEvent> {
-    return lifecycleRelay.hide()
+    return lifecycleFlow.asObservable()
   }
 
   /** @return true if the controller is attached, false if not. */
-  override fun isAttached() = behaviorRelay.value === InteractorEvent.ACTIVE
+  override fun isAttached() = lifecycleFlow.replayCache.last() == InteractorEvent.ACTIVE
 
   /**
    * Called when attached. The presenter will automatically be added when this happens.
@@ -97,7 +98,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   protected open fun onSaveInstanceState(outState: Bundle) {}
 
   public open fun dispatchAttach(savedInstanceState: Bundle?) {
-    lifecycleRelay.accept(InteractorEvent.ACTIVE)
+    lifecycleFlow.tryEmit(InteractorEvent.ACTIVE)
     (getPresenter() as? Presenter)?.dispatchLoad()
     didBecomeActive(savedInstanceState)
   }
@@ -105,7 +106,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   public open fun dispatchDetach(): P {
     (getPresenter() as? Presenter)?.dispatchUnload()
     willResignActive()
-    lifecycleRelay.accept(InteractorEvent.INACTIVE)
+    lifecycleFlow.tryEmit(InteractorEvent.INACTIVE)
     return getPresenter()
   }
 
@@ -140,7 +141,7 @@ abstract class Interactor<P : Any, R : Router<*>> : LifecycleScopeProvider<Inter
   }
 
   override fun peekLifecycle(): InteractorEvent? {
-    return behaviorRelay.value
+    return lifecycleFlow.replayCache.last()
   }
 
   final override fun requestScope(): CompletableSource {

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -16,11 +16,12 @@
 package com.uber.rib.core
 
 import androidx.annotation.CallSuper
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.PresenterEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.rx2.asObservable
 import org.checkerframework.checker.guieffect.qual.UIEffect
 
 /**
@@ -31,8 +32,7 @@ import org.checkerframework.checker.guieffect.qual.UIEffect
  * it becomes unclear where you should write your bussiness logic.
  */
 abstract class Presenter : ScopeProvider {
-  private val behaviorRelay = BehaviorRelay.create<PresenterEvent>()
-  private val lifecycleRelay = behaviorRelay.toSerialized()
+  private val lifecycleFlow = MutableSharedFlow<PresenterEvent>()
 
   /** @return `true` if the presenter is loaded, `false` if not. */
   protected var isLoaded = false
@@ -40,14 +40,14 @@ abstract class Presenter : ScopeProvider {
 
   public open fun dispatchLoad() {
     isLoaded = true
-    lifecycleRelay.accept(PresenterEvent.LOADED)
+    lifecycleFlow.tryEmit(PresenterEvent.LOADED)
     didLoad()
   }
 
   public open fun dispatchUnload() {
     isLoaded = false
     willUnload()
-    lifecycleRelay.accept(PresenterEvent.UNLOADED)
+    lifecycleFlow.tryEmit(PresenterEvent.UNLOADED)
   }
 
   /** Tells the presenter that it has finished loading.  */
@@ -66,10 +66,10 @@ abstract class Presenter : ScopeProvider {
 
   /** @return an observable of this controller's lifecycle events. */
   open fun lifecycle(): Observable<PresenterEvent> {
-    return lifecycleRelay.hide()
+    return lifecycleFlow.asObservable()
   }
 
   override fun requestScope(): CompletableSource {
-    return lifecycleRelay.skip(1).firstElement().ignoreElement()
+    return lifecycleFlow.drop(1).asObservable().firstElement().ignoreElement()
   }
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -74,6 +74,6 @@ abstract class Presenter : ScopeProvider {
   open fun lifecycle(): Observable<PresenterEvent> = lifecycleObservable
 
   override fun requestScope(): CompletableSource {
-    return rxCompletable(Dispatchers.Unconfined) { lifecycleFlow.take(2).collect() }
+    return rxCompletable(RibDispatchers.Unconfined) { lifecycleFlow.take(2).collect() }
   }
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -20,7 +20,8 @@ import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.PresenterEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.rx2.asObservable
 import org.checkerframework.checker.guieffect.qual.UIEffect
 

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -19,6 +19,7 @@ import androidx.annotation.CallSuper
 import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.PresenterEvent
 import io.reactivex.CompletableSource
+import io.reactivex.Observable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -70,7 +71,7 @@ abstract class Presenter : ScopeProvider {
   }
 
   /** @return an observable of this controller's lifecycle events. */
-  open fun lifecycle() = lifecycleObservable
+  open fun lifecycle(): Observable<PresenterEvent> = lifecycleObservable
 
   override fun requestScope(): CompletableSource {
     return rxCompletable(Dispatchers.Unconfined) { lifecycleFlow.take(2).collect() }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -20,7 +20,6 @@ import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.PresenterEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
@@ -15,14 +15,16 @@
  */
 package com.uber.rib.core
 
-import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.Observable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.rx2.asObservable
 
 class RibEvents private constructor() {
 
-  private val eventRelay: PublishRelay<RibEvent> = PublishRelay.create()
+  private val eventFlow = MutableSharedFlow<RibEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
-  open val events: Observable<RibEvent> = eventRelay.hide()
+  open val events: Observable<RibEvent> = eventFlow.asObservable()
 
   /**
    * @param eventType [RibEventType]
@@ -31,7 +33,7 @@ class RibEvents private constructor() {
    * RibActivity/Fragment
    */
   open fun emitEvent(eventType: RibEventType, child: Router<*>, parent: Router<*>?) {
-    eventRelay.accept(RibEvent(eventType, child, parent))
+    eventFlow.tryEmit(RibEvent(eventType, child, parent))
   }
 
   companion object {

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
@@ -22,9 +22,9 @@ import kotlinx.coroutines.rx2.asObservable
 
 class RibEvents private constructor() {
 
-  private val eventFlow = MutableSharedFlow<RibEvent>(0, 1, BufferOverflow.DROP_OLDEST)
+  private val _events = MutableSharedFlow<RibEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
-  open val events: Observable<RibEvent> = eventFlow.asObservable()
+  val events: Observable<RibEvent> = _events.asObservable()
 
   /**
    * @param eventType [RibEventType]
@@ -32,8 +32,8 @@ class RibEvents private constructor() {
    * @param parent [Router] and null for the root ribs that are directly attached to
    * RibActivity/Fragment
    */
-  open fun emitEvent(eventType: RibEventType, child: Router<*>, parent: Router<*>?) {
-    eventFlow.tryEmit(RibEvent(eventType, child, parent))
+  fun emitEvent(eventType: RibEventType, child: Router<*>, parent: Router<*>?) {
+    _events.tryEmit(RibEvent(eventType, child, parent))
   }
 
   companion object {

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -16,12 +16,15 @@
 package com.uber.rib.core
 
 import androidx.annotation.VisibleForTesting
-import com.jakewharton.rxrelay2.PublishRelay
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import com.uber.rib.core.lifecycle.InteractorEvent
 import com.uber.rib.core.lifecycle.PresenterEvent
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.Observable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.rx2.asObservable
 
 /** Helper class to bind to an interactor's lifecycle to translate it to a [Worker] lifecycle. */
 object WorkerBinder {
@@ -85,12 +88,14 @@ object WorkerBinder {
   @JvmStatic
   @VisibleForTesting
   open fun bind(mappedLifecycle: Observable<WorkerEvent>, worker: Worker): WorkerUnbinder {
-    val unbindSubject = PublishRelay.create<WorkerEvent>()
-    val workerLifecycle = mappedLifecycle
-      .mergeWith(unbindSubject)
-      .takeUntil { workerEvent: WorkerEvent -> workerEvent === WorkerEvent.STOP }
+    val unbindFlow = MutableSharedFlow<WorkerEvent>(0 ,1, BufferOverflow.DROP_OLDEST)
+
+    val workerLifecycle = merge( mappedLifecycle.asFlow(), unbindFlow)
+            .transformWhile { emit(it) ; it != WorkerEvent.STOP  }
+            .asObservable()
+
     bindToWorkerLifecycle(workerLifecycle, worker)
-    return WorkerUnbinder { unbindSubject.accept(WorkerEvent.STOP) }
+    return WorkerUnbinder { unbindFlow.tryEmit(WorkerEvent.STOP) }
   }
 
   @JvmStatic

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
@@ -19,10 +19,12 @@ import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.rx2.asFlow
-import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.rx2.rxCompletable
 
 /** [ScopeProvider] for [Worker] instances.  */
 open class WorkerScopeProvider internal constructor(
@@ -31,6 +33,8 @@ open class WorkerScopeProvider internal constructor(
   internal constructor(workerLifecycleObservable: Observable<WorkerEvent>) : this(workerLifecycleObservable.asFlow())
 
   override fun requestScope(): CompletableSource {
-    return workerLifecycle.drop(1).asObservable().firstElement().ignoreElement()
+    return rxCompletable(Dispatchers.Unconfined) {
+      workerLifecycle.take(2).collect()
+    }
   }
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
@@ -19,7 +19,6 @@ import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
@@ -28,12 +27,12 @@ import kotlinx.coroutines.rx2.rxCompletable
 
 /** [ScopeProvider] for [Worker] instances.  */
 open class WorkerScopeProvider internal constructor(
-  private val workerLifecycle: Flow<WorkerEvent>
+  private val workerLifecycle: Flow<WorkerEvent>,
 ) : ScopeProvider {
   internal constructor(workerLifecycleObservable: Observable<WorkerEvent>) : this(workerLifecycleObservable.asFlow())
 
   override fun requestScope(): CompletableSource {
-    return rxCompletable(Dispatchers.Unconfined) {
+    return rxCompletable(RibDispatchers.Unconfined) {
       workerLifecycle.take(2).collect()
     }
   }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
@@ -22,12 +22,11 @@ import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.rx2.asFlow
-import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.asObservable
 
 /** [ScopeProvider] for [Worker] instances.  */
 open class WorkerScopeProvider internal constructor(
-        private val workerLifecycle : Flow<WorkerEvent>
+  private val workerLifecycle: Flow<WorkerEvent>
 ) : ScopeProvider {
   internal constructor(workerLifecycleObservable: Observable<WorkerEvent>) : this(workerLifecycleObservable.asFlow())
 

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
@@ -19,12 +19,19 @@ import com.uber.autodispose.ScopeProvider
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.rx2.asFlowable
+import kotlinx.coroutines.rx2.asObservable
 
 /** [ScopeProvider] for [Worker] instances.  */
 open class WorkerScopeProvider internal constructor(
-  private val workerLifecycleObservable: Observable<WorkerEvent>
+        private val workerLifecycle : Flow<WorkerEvent>
 ) : ScopeProvider {
+  internal constructor(workerLifecycleObservable: Observable<WorkerEvent>) : this(workerLifecycleObservable.asFlow())
+
   override fun requestScope(): CompletableSource {
-    return workerLifecycleObservable.skip(1).firstElement().ignoreElement()
+    return workerLifecycle.drop(1).asObservable().firstElement().ignoreElement()
   }
 }

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
@@ -102,7 +102,6 @@ class InteractorAndRouterTest {
     }
     val router = TestRouterA(parentInteractor, component)
     val parentObserver = RecordingObserver<InteractorEvent>()
-    parentInteractor.lifecycle()
     parentInteractor.lifecycle().subscribe(parentObserver)
     router.dispatchAttach(null)
     Truth.assertThat(parentObserver.takeNext()).isEqualTo(InteractorEvent.ACTIVE)

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
@@ -102,6 +102,7 @@ class InteractorAndRouterTest {
     }
     val router = TestRouterA(parentInteractor, component)
     val parentObserver = RecordingObserver<InteractorEvent>()
+    parentInteractor.lifecycle()
     parentInteractor.lifecycle().subscribe(parentObserver)
     router.dispatchAttach(null)
     Truth.assertThat(parentObserver.takeNext()).isEqualTo(InteractorEvent.ACTIVE)

--- a/android/libraries/rib-router-navigator/build.gradle
+++ b/android/libraries/rib-router-navigator/build.gradle
@@ -22,7 +22,9 @@ targetCompatibility = deps.build.javaVersion.toString()
 
 dependencies {
     implementation deps.external.checkerQual
-    implementation deps.external.rxrelay2
+    implementation deps.uber.autodisposeCoroutines
+    implementation deps.kotlin.coroutinesAndroid
+    implementation deps.kotlin.coroutinesRx2
     implementation project(':libraries:rib-base')
     compileOnly deps.androidx.annotations
     compileOnly deps.apt.androidApi

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
@@ -15,7 +15,6 @@
  */
 package com.uber.rib.core
 
-import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -23,12 +22,10 @@ import kotlinx.coroutines.rx2.asObservable
 /** Class that provides its instance to emit or subscribe to [RouterNavigatorEvent]  */
 class RouterNavigatorEvents private constructor() {
 
-  private val events = MutableSharedFlow<RouterNavigatorEvent>(0, 1, BufferOverflow.DROP_OLDEST)
+  private val _events = MutableSharedFlow<RouterNavigatorEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
   /** @return the stream which can be subcribed to listen for [RouterNavigatorEvent] */
-  open fun getEvents(): Observable<RouterNavigatorEvent> {
-    return events.asObservable()
-  }
+  val events = _events.asObservable()
 
   /**
    * Emits a new [RouterNavigatorEvent] on the stream.
@@ -37,8 +34,8 @@ class RouterNavigatorEvents private constructor() {
    * @param parent router instance to which child will attach to.
    * @param child router instance which getting attached.
    */
-  open fun emitEvent(eventType: RouterNavigatorEventType, parent: Router<*>, child: Router<*>) {
-    events.tryEmit(RouterNavigatorEvent(eventType, parent, child))
+  fun emitEvent(eventType: RouterNavigatorEventType, parent: Router<*>, child: Router<*>) {
+    _events.tryEmit(RouterNavigatorEvent(eventType, parent, child))
   }
 
   companion object {

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
@@ -15,17 +15,19 @@
  */
 package com.uber.rib.core
 
-import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.Observable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.rx2.asObservable
 
 /** Class that provides its instance to emit or subscribe to [RouterNavigatorEvent]  */
 class RouterNavigatorEvents private constructor() {
 
-  private val events: PublishRelay<RouterNavigatorEvent> = PublishRelay.create()
+  private val events = MutableSharedFlow<RouterNavigatorEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
   /** @return the stream which can be subcribed to listen for [RouterNavigatorEvent] */
   open fun getEvents(): Observable<RouterNavigatorEvent> {
-    return events.hide()
+    return events.asObservable()
   }
 
   /**
@@ -36,7 +38,7 @@ class RouterNavigatorEvents private constructor() {
    * @param child router instance which getting attached.
    */
   open fun emitEvent(eventType: RouterNavigatorEventType, parent: Router<*>, child: Router<*>) {
-    events.accept(RouterNavigatorEvent(eventType, parent, child))
+    events.tryEmit(RouterNavigatorEvent(eventType, parent, child))
   }
 
   companion object {

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
@@ -15,6 +15,7 @@
  */
 package com.uber.rib.core
 
+import io.reactivex.Observable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -25,7 +26,7 @@ class RouterNavigatorEvents private constructor() {
   private val _events = MutableSharedFlow<RouterNavigatorEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
   /** @return the stream which can be subcribed to listen for [RouterNavigatorEvent] */
-  val events = _events.asObservable()
+  val events: Observable<RouterNavigatorEvent> = _events.asObservable()
 
   /**
    * Emits a new [RouterNavigatorEvent] on the stream.

--- a/android/libraries/rib-screen-stack-base/build.gradle
+++ b/android/libraries/rib-screen-stack-base/build.gradle
@@ -38,4 +38,7 @@ dependencies {
     api deps.external.rxrelay2
     api deps.external.rxbinding
     implementation deps.androidx.annotations
+    implementation deps.uber.autodisposeCoroutines
+    implementation deps.kotlin.coroutinesAndroid
+    implementation deps.kotlin.coroutinesRx2
 }


### PR DESCRIPTION
Beginning internal addressing of Rx usages in core artifacts.

- Currently replacing heavy use of Behavior/Publish Relays on internal code to track lifecycle state.
- Public APIs are still wrapped to observables.

- [x] Verify against internal test suite
- [x] Verify against app core flow functional expectations

https://github.com/uber/RIBs/issues/542
