### PR TITLE
Introduce `RibCoroutineWorker`

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
+
+/** A manager or helper class bound to a [CoroutineScope] by using a binder like [bind]. */
+public fun interface RibCoroutineWorker {
+  /** Called when worker is started. Children coroutines can be launched in [scope]. */
+  public suspend fun onStart(scope: CoroutineScope)
+
+  /** Called when the worker is stopped with the given [cause]. Should be fast, non-blocking and should not throw. */
+  @JvmDefault
+  public fun onStop(cause: Throwable) {}
+}
+
+// ---- Binder ---- //
+
+/**
+ * A handle to interact with [RibCoroutineWorker] binding job. This handle implements [Job], which refers to the
+ * completion of [RibCoroutineWorker.onStart]. It can be [joined][join] to make sure `onStart` finished. Note that
+ * children coroutines launched in the [CoroutineScope] passed on to `onStart` are not waited: worker is considered
+ * bound when `onStart` finishes.
+ */
+public sealed interface BindWorkerHandle : Job {
+  /** Unbinds the worker. */
+  public fun unbind(): Job
+}
+
+private class BindWorkerHandleImpl(
+  bindJob: Job,
+  private val unbindJob: Job,
+) : BindWorkerHandle, Job by bindJob {
+  override fun unbind(): Job {
+    unbindJob.cancel("Worker was manually unbound.")
+    return unbindJob
+  }
+}
+
+/**
+ * Binds [worker] in a scope that is a child of the [CoroutineScope] receiver.
+ *
+ * The binding operation runs [RibCoroutineWorker.onStart] in a context inherited from the [CoroutineScope] receiver, but
+ * with additional [context] elements that is, by default, [RibDispatchers.Default]. This makes the worker run on the
+ * default dispatcher by default. Pass in [EmptyCoroutineContext] instead if you want the worker to not override the
+ * dispatcher in the scope (if any), or pass in a custom dispatcher as [context] to specify a different dispatcher. If
+ * there is no dispatcher in [CoroutineScope] nor in [context], [RibDispatchers.Default] is used.
+ *
+ * The scope passed on to [RibCoroutineWorker.onStart] as a parameter is a child scope of the [CoroutineScope] receiver,
+ * but with the additional [context] elements and a [SupervisorJob].
+ *
+ * Binding a worker is an asynchronous operation. To ensure [RibCoroutineWorker.onStart] is finished, callers can
+ * [join][BindWorkerHandle.join] the resulting [BindWorkerHandle] when in a coroutine:
+ *
+ * ```
+ * val handle = coroutineScope.bind(worker)
+ * handle.join() // wait for onStart to finish
+ * ```
+ */
+@JvmOverloads
+public fun CoroutineScope.bind(
+  worker: RibCoroutineWorker,
+  context: CoroutineContext = RibDispatchers.Default,
+): BindWorkerHandle {
+  // A job that completes once worker's onStart completes
+  var bindJob: CompletableJob? = null
+  // Start the bind coroutine undispatched to make sure we set bindJob synchronously.
+  val unbindJob = launch(context, start = CoroutineStart.UNDISPATCHED) {
+    bindJob = Job(coroutineContext.job).also {
+      // Cancel `unbindJob` if `bindJob` has cancelled. This is important to abort `onStart` if `bindJob`
+      // gets cancelled externally.
+      // Note that in case of `bindJob` failure (e.g. `onStart` throws), `unbindJob` will already fail by means of
+      // structured concurrency, but that does not happen on normal cancellation.
+      // This `bindJob` cancellation upon the `unbindJob` cancellation is also already set through structured concurrency.
+      it.invokeOnCompletion { throwable -> if (throwable is CancellationException) cancel(throwable) }
+    }
+    // Verify cancellation and dispatch (if needed) using dispatcher in context instead of continuing on current thread.
+    dispatchIfNeeded()
+    bindAndAwaitCancellation(worker, bindJob!!)
+  }
+  // We know deferred is non-null because binding coroutine was started undispatched.
+  return BindWorkerHandleImpl(bindJob!!, unbindJob)
+}
+
+private suspend inline fun dispatchIfNeeded() {
+  suspendCoroutineUninterceptedOrReturn sc@{ cont ->
+    val context = cont.context
+    val dispatcher = context[ContinuationInterceptor] as CoroutineDispatcher
+    if (!dispatcher.isDispatchNeeded(context)) return@sc Unit
+    // Coroutine was not in the right context -- we'll dispatch.
+    context.ensureActive()
+    cont.intercepted().resume(Unit)
+    COROUTINE_SUSPENDED
+  }
+  coroutineContext.ensureActive() // Don't continue if coroutine was cancelled after returning from dispatch.
+}
+
+@Suppress("TooGenericExceptionCaught") // Exception is not swallowed
+private suspend fun bindAndAwaitCancellation(worker: RibCoroutineWorker, bindJob: CompletableJob) {
+  try {
+    supervisorScope {
+      worker.onStart(this)
+      ensureActive() // Before completing the binding deferred, make sure the binding coroutine is active.
+      bindJob.complete()
+      awaitCancellation() // Never returns normally, so we are sure an exception will be caught.
+    }
+  } catch (t: Throwable) {
+    bindJob.cancelOrCompleteExceptionally(t)
+    worker.onStop(t)
+  }
+}
+
+/** Cancel the deferred if [throwable] is a [CancellationException], otherwise completes it exceptionally. */
+private fun CompletableJob.cancelOrCompleteExceptionally(throwable: Throwable) {
+  when (throwable) {
+    is CancellationException -> cancel(throwable)
+    else -> completeExceptionally(throwable)
+  }
+}

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Delay
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.invoke
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Rule
+import org.junit.Test
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+private const val ON_START_DELAY_DURATION_MILLIS = 100L
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RibCoroutineWorkerTest {
+  @get:Rule
+  val coroutineRule = RibCoroutinesRule()
+  private val worker = TestRibCoroutineWorker()
+
+  @Test
+  fun bindWorkHandle_onJoin_thenJoinsBindingOperation() = runTest {
+    val handle = bind(worker, UnconfinedTestDispatcher(testScheduler))
+    assertThat(worker.onStartStarted).isTrue()
+    assertThat(worker.onStartFinished).isFalse()
+    handle.join()
+    assertThat(worker.onStartFinished).isTrue()
+    handle.unbind()
+  }
+
+  @Test
+  fun bind_onErrorOnStartAndOnStop_propagatesExceptionWithSuppressed() = runTest {
+    var throwable: Throwable? = null
+    val ceh = CoroutineExceptionHandler { _, t -> throwable = t }
+    withContext(ceh) {
+      supervisorScope {
+        val onStartErrorMsg = "onStart failure"
+        val onStopErrorMsg = "onStop failure"
+        worker.doOnStart { error(onStartErrorMsg) }
+        worker.doOnStop { error(onStopErrorMsg) }
+        bind(worker).join()
+        assertThat(throwable).isInstanceOf(IllegalStateException::class.java)
+        assertThat(throwable).hasMessageThat().isEqualTo(onStartErrorMsg)
+        val suppressed = throwable?.suppressed?.firstOrNull()
+        assertThat(suppressed).isInstanceOf(IllegalStateException::class.java)
+        assertThat(suppressed).hasMessageThat().isEqualTo(onStopErrorMsg)
+        assertThat(worker.onStartFinished).isTrue()
+        assertThat(worker.onStopFinished).isTrue()
+      }
+    }
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun bindWorkHandle_onError_thenPropagatesException() = runTest {
+    worker.doOnStart { error("onStart failure") }
+    bind(worker)
+  }
+
+  @Test
+  fun unbindHandler_onJoin_thenJoinsUnbindOperation() = runTest {
+    val bindHandle = bind(worker)
+    bindHandle.join()
+    val unbindHandle = bindHandle.unbind()
+    assertThat(worker.onStopFinished).isFalse()
+    unbindHandle.join()
+    assertThat(worker.onStopFinished).isTrue()
+    assertThat(worker.onStopCause).isInstanceOf(CancellationException::class.java)
+    assertThat(worker.onStopCause).hasMessageThat().isEqualTo("Worker was manually unbound.")
+  }
+
+  @Test
+  fun onScopeCancelledAfterBinding_workerIsUnboundAutomatically() = runTest {
+    val cancellationMsg = "Scope cancelled"
+    launch {
+      bind(worker, EmptyCoroutineContext).join()
+      cancel(cancellationMsg)
+    }
+    advanceUntilIdle()
+    assertThat(worker.onStopFinished).isTrue()
+    assertThat(worker.onStopCause).isInstanceOf(CancellationException::class.java)
+    assertThat(worker.onStopCause).hasMessageThat().isEqualTo(cancellationMsg)
+  }
+
+  @Test
+  fun onScopeCancelledBeforeBinding_parentScopeCanCompleteNormally() = runTest {
+    launch {
+      bind(worker)
+      // bind was called, but coroutine that runs onStart is not started yet.
+      cancel("Scope cancelling")
+    }
+    // if test fails to finish, there are unfinished jobs.
+  }
+
+  @Test
+  fun onBindingJobCancelledBeforeBinding_parentScopeCanCompleteNormally() = runTest {
+    launch {
+      bind(worker).cancel("Cancelling bind work")
+    }
+    // if test fails to finish, there are unfinished jobs.
+  }
+
+  @Test
+  fun onScopeCancelledOnWorkerOnStart_parentScopeCanCompleteNormally() = runTest {
+    val cancellationMsg = "Cancelling on onStart"
+    worker.doOnStart { currentCoroutineContext().cancel(CancellationException(cancellationMsg)) }
+    bind(worker).join()
+  }
+
+  @OptIn(DelicateCoroutinesApi::class)
+  @Test
+  fun onBindingWithCustomDispatcher_dispatchesToCustomDispatcher() = runTest {
+    val callingContext = newSingleThreadContext("Calling context")
+    val executionContext = newSingleThreadContext("Execution context")
+    executionContext.use { execCtx ->
+      callingContext.use { callingCtx ->
+        withContext(callingCtx) {
+          val handle = bind(worker, execCtx)
+          handle.join()
+          assertThat(worker.onStartThread!!.name).startsWith("Execution context")
+          handle.unbind().join()
+          assertThat(worker.onStopThread!!.name).startsWith("Execution context")
+        }
+      }
+    }
+  }
+
+  @Test
+  fun onBindingOnCorrectContext_doNotPayForDispatch() = runTest {
+    val dispatcher = ImmediateDispatcher(testScheduler)
+    dispatcher {
+      dispatcher.setThreadId()
+      assertThat(dispatcher.dispatchCount).isEqualTo(1)
+      val handle = bind(worker, EmptyCoroutineContext)
+      assertThat(dispatcher.dispatchCount).isEqualTo(1) // no new dispatch done
+      assertThat(worker.onStartStarted).isTrue() // started undispatched
+      assertThat(worker.onStartThread!!.id).isEqualTo(Thread.currentThread().id)
+      // run delay on onStart
+      advanceTimeBy(ON_START_DELAY_DURATION_MILLIS)
+      runCurrent()
+      assertThat(worker.onStartFinished).isTrue()
+      assertThat(dispatcher.dispatchCount).isEqualTo(1) // no new dispatch done
+      handle.unbind()
+      assertThat(worker.onStopThread!!.id).isEqualTo(Thread.currentThread().id)
+      assertThat(worker.onStopFinished).isTrue()
+    }
+  }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
+private class ImmediateDispatcher(
+  scheduler: TestCoroutineScheduler,
+  private val delegate: TestDispatcher = StandardTestDispatcher(scheduler)
+) : CoroutineDispatcher(), Delay by delegate {
+  private var threadId: Long? = null
+  var dispatchCount = 0
+    private set
+
+  override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+    val expectedThreadId = threadId ?: return true
+    return Thread.currentThread().id != expectedThreadId
+  }
+
+  override fun dispatch(context: CoroutineContext, block: Runnable) {
+    ++dispatchCount
+    delegate.dispatch(context, block)
+  }
+
+  fun setThreadId() {
+    threadId = Thread.currentThread().id
+  }
+}
+
+private class TestRibCoroutineWorker : RibCoroutineWorker {
+  var onStartStarted = false
+  var onStartFinished = false
+  var onStartThread: Thread? = null
+  var onStopCause: Throwable? = null
+  var onStopFinished = false
+  var onStopThread: Thread? = null
+
+  private var _doOnStart: suspend () -> Unit = {}
+  private var _doOnStop: () -> Unit = {}
+
+  fun doOnStart(block: suspend () -> Unit) {
+    _doOnStart = block
+  }
+
+  fun doOnStop(block: () -> Unit) {
+    _doOnStop = block
+  }
+
+  override suspend fun onStart(scope: CoroutineScope) {
+    onStartStarted = true
+    onStartThread = Thread.currentThread()
+    try {
+      scope.launch { awaitCancellation() }
+      delay(ON_START_DELAY_DURATION_MILLIS)
+      _doOnStart()
+    } finally {
+      onStartFinished = true
+    }
+  }
+
+  override fun onStop(cause: Throwable) {
+    onStopThread = Thread.currentThread()
+    onStopCause = cause
+    try {
+      _doOnStop()
+    } finally {
+      onStopFinished = true
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
Introduces `RibCoroutineWorker`, a worker version with a suspending `onStart, a (non-suspending) `onStop` that takes in the termination cause, and more flexible binding capabilities.

## API comparison

The `RibCoroutineWorker ` contract is as follows:
```kotlin
public fun interface RibCoroutineWorker {
  /** Called when worker is started. Children coroutines can be launched in [scope]. */
  public suspend fun onStart(scope: CoroutineScope)

  /** Called when the worker is stopped with the given [cause]. Should be fast, non-blocking and should not throw. */
  public fun onStop(cause: Throwable) {}
}
```
As it can be seen, `RibCoroutineWorker` interface is very similar to `Worker`'s, but 
1. It has a suspend `onStart` that takes in a `CoroutineScope` (as opposed to non-suspend `onStart` that takes in a `WorkerScopeProvider`)
2. `onStop` receives the cancellation cause (parent scope cancelled, or worker manually cancelled by unbinder, or `onStart` method threw an exception, meaning binding failed).

Binding to a worker requires a `CoroutineScope` instead of an `Interactor` or `Presenter`. Any `ScopeProvider` can bind a worker through the `ScopeProvider.coroutineScope` extension.

```kotlin
public fun CoroutineScope.bind(worker: RibCoroutineWorker): BindWorkerHandle
```

```kotlin
override fun didBecomeActive() {
  coroutineScope.bind(worker)
}
```

Binding operation is non-suspending and is asynchronous, but unlike `Worker` binding API, it can be `joined` using the resulting `BindWorkerHandle`.

```kotlin
/**
 * A handle to interact with [RibCoroutineWorker] binding job. This handle implements [Job], which refers to the
 * completion of [RibCoroutineWorker.onStart]. It can be [joined][join] to make sure
 * [RibCoroutineWorker.onStart] finished.
 */
public sealed interface BindWorkerHandle : Job {
  /** Unbinds the worker. */
  public fun unbind(): Job
}
```

This allows for (hopefully) useful feedback to the caller component:
1. It can, on a coroutine, `join`ed to wait for `onStart` to finish. Exceptions are propagated to the parent.
2. `unbind()` is also asynchronous but returns an `Job` which can also be `joined`, so caller can know unbinding is completed:

Example:
```kotlin
override fun didBecomeActive() {
  // start worker binding work asynchronously
  val handle: BindWorkerHandle = coroutineScope.bind(worker)
  coroutineScope.launch {
    handle.join() // onStart finished. Failures are propagated upwards.
    handle.unbind().join() // onStop finished
  } 
}
```

## Alternative API considered

1. Suspending `onStop`

`onStop` is non-suspending. Suspending `onStop` was considered, but it's troublesome: by the time it is called, the scope may have completed already (for example, parent scope was cancelled externally). So `onStop` would fail at suspension points.

2. Suspending `onStart` that does not take in a `CoroutineScope`.
We could have a suspending `onStart` that does not take in a scope, but can open a scope itself to launch children coroutines:
```kotlin
suspend fun onStart() {
  coroutineScope {
    someFlow.launchIn(this)
  }
}
```

This API is fine, but if non-terminating flows (such as `SharedFlow` or `StateFlow`) are collected inside `onStart`, `onStart` would never terminate successfully, and binder caller would have no way to know if `onStart` finished itself but still has children coroutines running (flow collectors). It would probably be a source of surprise that `BindWorkerHandle.join()` would never return.

3. Non-suspending `onStart` that takes in a `CoroutineScope`
This would be the most similar to `Worker` API and, as the `Worker`, would require launching new coroutines every time we want to use a suspending function. Because all suspending work would be done in children coroutines, binder would have no way to know the suspending operations completed (which is the current form of `Worker`).

4. Suspending binding and unbinding operations.
This suspending API for binding and unbinding would minimize the Handles API (as joining, awaiting, etc would not be necessary), but would require to launch a coroutine just for binding in Interactors (repetitive and cumbersome to use), when we may not care about waiting for `onStart` to complete. 
```kotlin
override fun didBecomeActive() {
  coroutineScope.launch {
    coroutineScope.bind(worker) // suspending, returns only after onStart completes
  }
}
```
Also, it is confusing to have a function that both takes in a `CoroutineScope` (implying it launches work asynchronously) and also is suspending (implying that by the time it returns, all pending work has been done).

## Validation

Validated with a local build the following behaviors:
1. `onStart` is called by default on `RibDispatchers.Default` context.
2.  Overriding dispatcher in `bind` works.
3. `onStop` is always called on `onStart` failure, scope cancellation, and on manual unbinding.
4. `onStop` execution context is defined by the `CoroutineDispatcher`.
5. Best-effort synchronicity is respected in immediate dispatchers such as `Dispatchers.Main.immediate`. 
6. Verified `BindWorkerHandle` `join` and `unbind`.

Also introduced unit tests to verify most of the above behavior.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
Fixes #546 

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
