### PR TITLE
Fix router navigator events source compatibility

### DIFF
--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
@@ -28,6 +28,14 @@ class RouterNavigatorEvents private constructor() {
   /** @return the stream which can be subcribed to listen for [RouterNavigatorEvent] */
   val events: Observable<RouterNavigatorEvent> = _events.asObservable()
 
+  @JvmSynthetic // Hide from Java consumers. In Java, `getEvents` resolves to the `events` property.
+  @JvmName("_getEvents")
+  @Deprecated( // Deprecate for Kotlin consumers.
+    message = "Use the 'events' property",
+    replaceWith = ReplaceWith("events")
+  )
+  public fun getEvents(): Observable<RouterNavigatorEvent> = events
+
   /**
    * Emits a new [RouterNavigatorEvent] on the stream.
    *


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: 93dd6e8d changed `getEvents()` to `events` property. This is fine for Java consumers, as `events` getter resolves to `getEvents()` in JVM, but Kotlin consumers using `getEvents()` will fail compilation, as this method no longer exists.

This commit introduces a deprecated, JVM synthetic `getEvents` methods to keep Kotlin source compatibility.

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
