### PR TITLE
Redesign RouterAndState to avoid router caching

### DIFF
--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterAndState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterAndState.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Internal class for keeping track of a navigation stack.
+ *
+ * @param state The associated state
+ * @param attachTransition The [RouterNavigator.AttachTransition] associated with this state.
+ * @param detachTransition The [RouterNavigator.DetachTransition] associated with this state.
+ * @param forceRouterCaching Override [RouterNavigatorState.isCacheable] behavior
+ */
+internal class RouterAndState<R : Router<*>, StateT : RouterNavigatorState>(
+  val state: StateT,
+  private val attachTransition: RouterNavigator.AttachTransition<R, StateT>,
+  detachTransition: RouterNavigator.DetachTransition<R, StateT>?,
+  @get:VisibleForTesting val forceRouterCaching: Boolean = false
+) {
+  @get:Synchronized
+  @set:Synchronized
+  private var _router: R? = null
+
+  /**
+   * Gets or creates the [Router] associated with this state. Router will be destroyed after
+   * [RouterNavigator.DetachCallback.onPostDetachFromHost] and if [StateT] is cacheable.
+   *
+   * @return [Router]
+   */
+  internal val router: R
+    @Synchronized
+    get() =
+      _router
+        ?: attachTransition.buildRouter().apply {
+          log("Router ${this@apply.javaClass.simpleName} was created")
+          _router = this@apply
+        }
+
+  internal fun willAttachToHost(previousState: StateT?, isPush: Boolean) =
+    attachTransition.willAttachToHost(router, previousState, state, isPush)
+
+  internal fun willDetachFromHost(
+    newState: StateT?,
+    isPush: Boolean
+  ) = detachCallback.willDetachFromHost(router, state, newState, isPush)
+
+  internal fun onPostDetachFromHost(newState: StateT?, isPush: Boolean) =
+    detachCallback.onPostDetachFromHost(router, newState, isPush)
+
+  /**
+   * Gets the [RouterNavigator.DetachCallback] associated with this state.
+   *
+   * @return [RouterNavigator.DetachCallback]
+   */
+  private val detachCallback: RouterNavigator.DetachCallback<R, StateT> by lazy {
+    RouterDestroyerCallbackWrapper(
+      baseCallback = wrapDetachTransitionIfNeed(detachTransition),
+      onDestroy = ::destroyRouterIfNeed
+    )
+  }
+
+  private fun wrapDetachTransitionIfNeed(
+    detachTransition: RouterNavigator.DetachTransition<R, StateT>?
+  ): RouterNavigator.DetachCallback<R, StateT>? {
+    return (detachTransition as? RouterNavigator.DetachCallback)
+      ?: detachTransition?.let { DetachCallbackWrapper(it) }
+  }
+
+  private fun destroyRouterIfNeed() {
+    if (!forceRouterCaching && !state.isCacheable()) {
+      val routerName = _router?.javaClass?.simpleName
+      _router = null
+      if (routerName != null) {
+        log("Destroying router $routerName was destroyed")
+      } else {
+        log("Router of ${state.stateName()} state already destroyed")
+      }
+    }
+  }
+
+  /**
+   * Wrapper class to wrap [RouterNavigator.DetachTransition] calls into the new
+   * [RouterNavigator.DetachCallback] format.
+   *
+   * @param transitionCallback Base transaction
+   */
+  private inner class DetachCallbackWrapper(
+    private val transitionCallback: RouterNavigator.DetachTransition<R, StateT>
+  ) : RouterNavigator.DetachCallback<R, StateT>() {
+
+    override fun willDetachFromHost(
+      router: R,
+      previousState: StateT,
+      newState: StateT?,
+      isPush: Boolean
+    ) {
+      transitionCallback.willDetachFromHost(router, previousState, newState, isPush)
+    }
+  }
+
+  private inner class RouterDestroyerCallbackWrapper(
+    private val baseCallback: RouterNavigator.DetachCallback<R, StateT>?,
+    private val onDestroy: () -> Unit
+  ) : RouterNavigator.DetachCallback<R, StateT>() {
+
+    override fun willDetachFromHost(
+      router: R,
+      previousState: StateT,
+      newState: StateT?,
+      isPush: Boolean
+    ) {
+      baseCallback?.willDetachFromHost(router, previousState, newState, isPush)
+    }
+
+    override fun onPostDetachFromHost(router: R, newState: StateT?, isPush: Boolean) {
+      baseCallback?.onPostDetachFromHost(router, newState, isPush)
+      onDestroy.invoke()
+    }
+  }
+
+  companion object {
+    /** Writes out to the debug log. */
+    private fun log(text: String) {
+      Rib.getConfiguration().handleDebugMessage("%s: $text", "RouterNavigator")
+    }
+  }
+}

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
@@ -28,7 +28,7 @@ import org.checkerframework.checker.guieffect.qual.UIEffect
 interface RouterNavigator<StateT : RouterNavigatorState> {
   /** Determine how pushes will affect the stack  */
   enum class Flag {
-    /** Push a new state to the top of the stack.  */
+    /** Push a new state to the top of the navigation stack.  */
     DEFAULT,
 
     /** Push a state that will not be retained when the next state is pushed.  */
@@ -79,7 +79,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * state already.
    *
    *
-   * NOTE: This will retain the Riblet in memory until it is popped or detached by a push with
+   * NOTE: This will retain the Riblet in memory (if [RouterNavigatorState.isCacheable] is TRUE) until it is popped or detached by a push with
    * certain flags.
    *
    * @param newState to switch to.
@@ -99,7 +99,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * provided.
    *
    *
-   * NOTE: This will retain the Riblet in memory until it is popped or detached by a push with
+   * NOTE: This will retain the Riblet in memory (if [RouterNavigatorState.isCacheable] is TRUE) until it is popped or detached by a push with
    * certain flags.
    *
    * @param newState to switch to.
@@ -119,7 +119,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * state already.
    *
    *
-   * NOTE: This will retain the Riblet in memory until it is popped. To push transient, riblets,
+   * NOTE: This will retain the Riblet in memory (if [RouterNavigatorState.isCacheable] is TRUE) until it is popped. To push transient, riblets,
    * use [RouterNavigator.pushTransientState]
    *
    *
@@ -142,7 +142,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * state already.
    *
    *
-   * NOTE: This will retain the Riblet in memory until it is popped. To push transient, riblets,
+   * NOTE: This will retain the Riblet in memory (if [RouterNavigatorState.isCacheable] is TRUE) until it is popped. To push transient, riblets,
    * use [RouterNavigator.pushTransientState]
    *
    *
@@ -306,70 +306,5 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
       newState: StateT?,
       isPush: Boolean
     )
-  }
-
-  /** Internal class for keeping track of a navigation stack.  */
-  class RouterAndState<StateT : RouterNavigatorState?> internal constructor(
-    /**
-     * Gets the [Router] associated with this state.
-     *
-     * @return [Router]
-     */
-    open val router: Router<*>,
-    /**
-     * Gets the state.
-     *
-     * @return [StateT]
-     */
-    open val state: StateT,
-    /**
-     * Gets the [AttachTransition] associated with this state.
-     *
-     * @return [AttachTransition]
-     */
-    internal open val attachTransition: AttachTransition<*, *>,
-    detachTransition: DetachTransition<*, *>?
-  ) {
-    /**
-     * Gets the [DetachCallback] associated with this state.
-     *
-     * @return [DetachCallback]
-     */
-    internal open var detachCallback: DetachCallback<*, *>? = null
-
-    init {
-      detachCallback = if (detachTransition != null) {
-        if (detachTransition is DetachCallback<*, *>) {
-          detachTransition
-        } else {
-          DetachCallbackWrapper(detachTransition)
-        }
-      } else {
-        null
-      }
-    }
-  }
-
-  /**
-   * Wrapper class to wrap [DetachTransition] calls into the new [DetachCallback]
-   * format.
-   *
-   * @param <RouterT> [RouterT]
-   * @param <StateT> [StateT]
-   </StateT></RouterT> */
-  class DetachCallbackWrapper<RouterT : Router<*>, StateT : RouterNavigatorState> internal constructor(
-    transitionCallback: DetachTransition<RouterT, StateT>
-  ) : DetachCallback<RouterT, StateT>() {
-
-    private val transitionCallback: DetachTransition<RouterT, StateT> = transitionCallback
-
-    override fun willDetachFromHost(
-      router: RouterT,
-      previousState: StateT,
-      newState: StateT?,
-      isPush: Boolean
-    ) {
-      transitionCallback.willDetachFromHost(router, previousState, newState, isPush)
-    }
   }
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
@@ -27,4 +27,18 @@ interface RouterNavigatorState {
       throw java.lang.AssertionError("Must be implemented by enum or override stateName()")
     }
   }
+
+  /**
+   * @return Boolean flag configure router caching behavior between transactions.
+   *
+   * TRUE - same instance of router will be reused in all [RouterNavigator.AttachTransition] (not
+   * recommended as might produce memory leak. Usage of [Router.dispatchAttach] and
+   * [Router.saveInstanceState] is preferred option)
+   *
+   * FALSE - router instance will be destroyed after
+   * [RouterNavigator.DetachCallback.onPostDetachFromHost] and will be recreated for next
+   * [RouterNavigator.AttachTransition]
+   */
+  @JvmDefault
+  fun isCacheable(): Boolean = false
 }

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/RouterAndStateTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/RouterAndStateTest.kt
@@ -15,8 +15,10 @@
  */
 package com.uber.rib.core
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -24,136 +26,111 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
 
 class RouterAndStateTest {
 
   private val state = mock<RouterNavigatorState>()
-  private val attachTransition = mock<RouterNavigator.AttachTransition<Router<*>, RouterNavigatorState>> {
-    on { buildRouter() } doAnswer { mock() } // Creates new instance per each invocation
-  }
-  private val detachTransition = mock<RouterNavigator.DetachTransition<Router<*>, RouterNavigatorState>>()
-  private val detachCallback = mock<RouterNavigator.DetachCallback<Router<*>, RouterNavigatorState>>()
+  private val attachTransition =
+    mock<RouterNavigator.AttachTransition<Router<*>, RouterNavigatorState>> {
+      on { buildRouter() } doAnswer { mock() } // Creates new instance per each invocation
+    }
+  private val detachTransition =
+    mock<RouterNavigator.DetachTransition<Router<*>, RouterNavigatorState>>()
+  private val detachCallback =
+    mock<RouterNavigator.DetachCallback<Router<*>, RouterNavigatorState>>()
 
   @Test
   fun router_whenStateIsNotCacheable_NotForcedToCache_shouldDestroyRouterAfterDetach() {
     whenever(state.isCacheable()).doReturn(false)
 
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition,
-      forceRouterCaching = false
-    )
+    val routerAndState =
+      RouterAndState(state, attachTransition, detachTransition, forceRouterCaching = false)
 
     val router1 = routerAndState.router
     routerAndState.onPostDetachFromHost(mock(), false)
     val router2 = routerAndState.router
 
-    Truth.assertThat(router1).isNotSameAs(router2)
+    assertThat(router1).isNotSameAs(router2)
   }
 
   @Test
   fun router_whenStateIsCacheable_NotForcedToCache_shouldReuseRouterOnNextAttach() {
     whenever(state.isCacheable()).doReturn(true)
 
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition,
-      forceRouterCaching = false
-    )
+    val routerAndState =
+      RouterAndState(state, attachTransition, detachTransition, forceRouterCaching = false)
 
     val router1 = routerAndState.router
     routerAndState.onPostDetachFromHost(mock(), false)
     val router2 = routerAndState.router
 
-    Truth.assertThat(router1).isSameAs(router2)
+    assertThat(router1).isSameAs(router2)
   }
 
   @Test
   fun router_whenStateIsNotCacheable_ForcedToCache_shouldReuseRouterOnNextAttach() {
     whenever(state.isCacheable()).doReturn(false)
 
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition,
-      forceRouterCaching = true
-    )
+    val routerAndState =
+      RouterAndState(state, attachTransition, detachTransition, forceRouterCaching = true)
 
     val router1 = routerAndState.router
     routerAndState.onPostDetachFromHost(mock(), false)
     val router2 = routerAndState.router
 
-    Truth.assertThat(router1).isSameAs(router2)
+    assertThat(router1).isSameAs(router2)
   }
 
   @Test
   fun router_whenStateIsCacheable_ForcedToCache_shouldReuseRouterOnNextAttach() {
     whenever(state.isCacheable()).doReturn(true)
 
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition,
-      forceRouterCaching = true
-    )
+    val routerAndState =
+      RouterAndState(state, attachTransition, detachTransition, forceRouterCaching = true)
 
     val router1 = routerAndState.router
     routerAndState.onPostDetachFromHost(mock(), false)
     val router2 = routerAndState.router
 
-    Truth.assertThat(router1).isSameAs(router2)
+    assertThat(router1).isSameAs(router2)
   }
 
   @Test
   fun willAttachToHost_shouldCallProvidedAttachCallback() {
 
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition
-    )
+    val routerAndState = RouterAndState(state, attachTransition, detachTransition)
 
     routerAndState.willAttachToHost(null, false)
 
-    verify(attachTransition).willAttachToHost(same(routerAndState.router), eq(null), same(state), eq(false))
+    verify(attachTransition)
+      .willAttachToHost(same(routerAndState.router), eq(null), same(state), eq(false))
   }
 
   @Test
   fun willDetachFromHost_whenDetachTransactionIsNotCallback_shouldCallProvidedDetachCallback() {
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition
-    )
+    val routerAndState = RouterAndState(state, attachTransition, detachTransition)
 
     routerAndState.willDetachFromHost(null, false)
 
-    verify(detachTransition).willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
+    verify(detachTransition)
+      .willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
   }
 
   @Test
   fun willDetachFromHost_whenDetachTransactionIsCallback_shouldCallProvidedDetachCallback() {
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachCallback
-    )
+    val routerAndState = RouterAndState(state, attachTransition, detachCallback)
 
     routerAndState.willDetachFromHost(null, false)
 
-    verify(detachCallback).willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
+    verify(detachCallback)
+      .willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
   }
 
   @Test
   fun willDetachFromHost_whenDetachTransactionIsNotCallback_shouldCallProvidedDetachTransaction() {
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachTransition,
-      forceRouterCaching = true
-    )
+    val routerAndState = RouterAndState(state, attachTransition, detachTransition)
 
     val router1 = routerAndState.router
     routerAndState.willDetachFromHost(null, false)
@@ -163,16 +140,51 @@ class RouterAndStateTest {
 
   @Test
   fun onPostDetachFromHost_shouldCallProvidedDetachCallback() {
-    val routerAndState = RouterAndState(
-      state,
-      attachTransition,
-      detachCallback,
-      forceRouterCaching = true
-    )
+    val routerAndState = RouterAndState(state, attachTransition, detachCallback)
 
     val router1 = routerAndState.router
     routerAndState.onPostDetachFromHost(null, false)
 
     verify(detachCallback).onPostDetachFromHost(same(router1), eq(null), eq(false))
+  }
+
+  @Test
+  fun router_whenCurrentlyDestroyingTheInstance_shouldCallBuilderTwice() {
+    val createdRouters = mutableSetOf<Router<*>>()
+    val destroyedRouters = mutableSetOf<Router<*>>()
+
+    whenever(attachTransition.buildRouter()).doAnswer {
+      mock<Router<*>>().apply(createdRouters::add)
+    }
+    whenever(detachCallback.onPostDetachFromHost(any(), anyOrNull(), any())).then {
+      destroyedRouters.add(it.arguments[0] as Router<*>)
+    }
+
+    val routerAndState =
+      RouterAndState(
+        state,
+        attachTransition,
+        detachCallback,
+      )
+
+    val threadsCount = 10
+    val latch = CountDownLatch(threadsCount)
+
+    // Create 10 threads with 1000 routers usage flows inside each
+    repeat(threadsCount) {
+      thread {
+        repeat(1000) {
+          routerAndState.willAttachToHost(null, false)
+          routerAndState.willDetachFromHost(null, false)
+          routerAndState.onPostDetachFromHost(null, false)
+        }
+        latch.countDown()
+      }
+    }
+
+    latch.await()
+
+    // Verify that all attached routers were detached
+    assertThat(createdRouters.subtract(destroyedRouters)).isEmpty()
   }
 }

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/RouterAndStateTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/RouterAndStateTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RouterAndStateTest {
+
+  private val state = mock<RouterNavigatorState>()
+  private val attachTransition = mock<RouterNavigator.AttachTransition<Router<*>, RouterNavigatorState>> {
+    on { buildRouter() } doAnswer { mock() } // Creates new instance per each invocation
+  }
+  private val detachTransition = mock<RouterNavigator.DetachTransition<Router<*>, RouterNavigatorState>>()
+  private val detachCallback = mock<RouterNavigator.DetachCallback<Router<*>, RouterNavigatorState>>()
+
+  @Test
+  fun router_whenStateIsNotCacheable_NotForcedToCache_shouldDestroyRouterAfterDetach() {
+    whenever(state.isCacheable()).doReturn(false)
+
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition,
+      forceRouterCaching = false
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.onPostDetachFromHost(mock(), false)
+    val router2 = routerAndState.router
+
+    Truth.assertThat(router1).isNotSameAs(router2)
+  }
+
+  @Test
+  fun router_whenStateIsCacheable_NotForcedToCache_shouldReuseRouterOnNextAttach() {
+    whenever(state.isCacheable()).doReturn(true)
+
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition,
+      forceRouterCaching = false
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.onPostDetachFromHost(mock(), false)
+    val router2 = routerAndState.router
+
+    Truth.assertThat(router1).isSameAs(router2)
+  }
+
+  @Test
+  fun router_whenStateIsNotCacheable_ForcedToCache_shouldReuseRouterOnNextAttach() {
+    whenever(state.isCacheable()).doReturn(false)
+
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition,
+      forceRouterCaching = true
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.onPostDetachFromHost(mock(), false)
+    val router2 = routerAndState.router
+
+    Truth.assertThat(router1).isSameAs(router2)
+  }
+
+  @Test
+  fun router_whenStateIsCacheable_ForcedToCache_shouldReuseRouterOnNextAttach() {
+    whenever(state.isCacheable()).doReturn(true)
+
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition,
+      forceRouterCaching = true
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.onPostDetachFromHost(mock(), false)
+    val router2 = routerAndState.router
+
+    Truth.assertThat(router1).isSameAs(router2)
+  }
+
+  @Test
+  fun willAttachToHost_shouldCallProvidedAttachCallback() {
+
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition
+    )
+
+    routerAndState.willAttachToHost(null, false)
+
+    verify(attachTransition).willAttachToHost(same(routerAndState.router), eq(null), same(state), eq(false))
+  }
+
+  @Test
+  fun willDetachFromHost_whenDetachTransactionIsNotCallback_shouldCallProvidedDetachCallback() {
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition
+    )
+
+    routerAndState.willDetachFromHost(null, false)
+
+    verify(detachTransition).willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
+  }
+
+  @Test
+  fun willDetachFromHost_whenDetachTransactionIsCallback_shouldCallProvidedDetachCallback() {
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachCallback
+    )
+
+    routerAndState.willDetachFromHost(null, false)
+
+    verify(detachCallback).willDetachFromHost(same(routerAndState.router), same(state), eq(null), eq(false))
+  }
+
+  @Test
+  fun willDetachFromHost_whenDetachTransactionIsNotCallback_shouldCallProvidedDetachTransaction() {
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachTransition,
+      forceRouterCaching = true
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.willDetachFromHost(null, false)
+
+    verify(detachTransition).willDetachFromHost(same(router1), same(state), eq(null), eq(false))
+  }
+
+  @Test
+  fun onPostDetachFromHost_shouldCallProvidedDetachCallback() {
+    val routerAndState = RouterAndState(
+      state,
+      attachTransition,
+      detachCallback,
+      forceRouterCaching = true
+    )
+
+    val router1 = routerAndState.router
+    routerAndState.onPostDetachFromHost(null, false)
+
+    verify(detachCallback).onPostDetachFromHost(same(router1), eq(null), eq(false))
+  }
+}

--- a/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
+++ b/android/libraries/rib-router-navigator/src/test/kotlin/com/uber/rib/core/StackRouterNavigatorTest.kt
@@ -596,4 +596,22 @@ class StackRouterNavigatorTest {
     routerNavigator.popState()
     Truth.assertThat(routerNavigator.peekState()).isNull()
   }
+
+  @Test
+  fun buildNewState_whenForceRouterCachingDisabled_shouldPassCorrectConfigInConstructor() {
+    routerNavigator = StackRouterNavigator(hostRouter, forceRouterCaching = false)
+    routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
+    routerNavigator.navigationStack.forEach { routerAndState ->
+      Truth.assertThat(routerAndState.forceRouterCaching).isEqualTo(false)
+    }
+  }
+
+  @Test
+  fun buildNewState_whenForceRouterCachingEnabled_shouldPassCorrectConfigInConstructor() {
+    routerNavigator = StackRouterNavigator(hostRouter, forceRouterCaching = true)
+    routerNavigator.pushState(TestState.STATE_1, attachTransition1, detachTransition1)
+    routerNavigator.navigationStack.forEach { routerAndState ->
+      Truth.assertThat(routerAndState.forceRouterCaching).isEqualTo(true)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
This change resolves possible memory leaks produced by storing `router` instances in the `RouterAndState` objects. 
<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: NONE reported yet

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
**Leak canary:**
<img width="314" alt="Screenshot 2023-04-14 at 10 55 41 AM" src="https://user-images.githubusercontent.com/82111345/232121846-22a03c9d-6a92-46b0-80e7-5ebf2f0e8b96.png">

