### PR TITLE
Reduce `Rx` <-> `Coroutines` interop and allow unconfined coroutines to run eagerly inside Worker's onStart

### DIFF
--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation deps.apt.javaxInject
 
     implementation deps.uber.autodisposeCoroutines
-    implementation deps.kotlin.coroutinesAndroid
+    implementation deps.kotlin.coroutines
     implementation deps.kotlin.coroutinesRx2
 
     implementation project(":libraries:rib-coroutines")

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmSynthetic
+
+package com.uber.rib.core
+
+import com.uber.autodispose.ScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleEndedException
+import com.uber.autodispose.lifecycle.LifecycleNotStartedException
+import io.reactivex.CompletableSource
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.rx2.rxCompletable
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/** Converts a [SharedFlow] of lifecycle events into a [ScopeProvider]. See [asScopeCompletable] for constraints. */
+internal fun <T : Comparable<T>> SharedFlow<T>.asScopeProvider(
+  range: ClosedRange<T>,
+  context: CoroutineContext = EmptyCoroutineContext,
+): ScopeProvider = asScopeCompletable(range, context).asScopeProvider()
+
+/**
+ * Converts a [SharedFlow] of lifecycle events into a [CompletableSource] that completes once the flow emits the ending
+ * event.
+ *
+ * The lifecycle start and end events are defined by [range], and this function will throw either:
+ * 1. [LifecycleNotStartedException], if the last emitted event is not in range, or
+ * 2. [LifecycleEndedException], if the last emitted event is in the end (inclusive) or beyond [range].
+ */
+internal fun <T : Comparable<T>> SharedFlow<T>.asScopeCompletable(
+  range: ClosedRange<T>,
+  context: CoroutineContext = EmptyCoroutineContext,
+): CompletableSource {
+  ensureAlive(range)
+  return rxCompletable(RibDispatchers.Unconfined + context) {
+    first { it == range.endInclusive }
+  }
+}
+
+private fun <T : Comparable<T>> SharedFlow<T>.ensureAlive(range: ClosedRange<T>) {
+  val lastEmitted = replayCache.lastOrNull()
+  when {
+    lastEmitted == null || lastEmitted < range.start -> throw LifecycleNotStartedException()
+    lastEmitted >= range.endInclusive -> throw LifecycleEndedException()
+  }
+}
+
+private fun CompletableSource.asScopeProvider() = ScopeProvider { this }

--- a/android/libraries/rib-coroutines-test/src/test/kotlin/com/uber/rib/core/RibScopesTest.kt
+++ b/android/libraries/rib-coroutines-test/src/test/kotlin/com/uber/rib/core/RibScopesTest.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import java.lang.RuntimeException
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -81,6 +80,7 @@ internal class RibScopesTest {
     assertThat(interactor1mainScope1).isNotEqualTo(interactor2mainScope1)
   }
 
+  // Bad test: The RuntimeException thrown is actually NoSuchElementException (handler exceptions is empty).
   @Test(expected = RuntimeException::class)
   internal fun testUncaughtHandler() = runTest {
     val handler = TestUncaughtExceptionCaptor()
@@ -94,6 +94,8 @@ internal class RibScopesTest {
     throw(handler.exceptions.first())
   }
 
+  // Bad test: The RuntimeException is actually thrown by Interactor.requestScope(), because it is called before
+  // attaching the interactor.
   @Test(expected = RuntimeException::class)
   internal fun testException() = runTest {
 


### PR DESCRIPTION
Reducing RxJava <-> Coroutines interop minimizes the chances for surprising behavior. A flow converted to Rx converted to a Flow converted to Rx (...) will run multiple nested coroutines using `Dispatchers.Undispatched` (as per `Flow.asObservable()`), which will form event loops that we want to avoid.

This PR also changes worker binding implementation (`bind(Interactor, Worker)`) to use the non-converted Interactor lifecycle, and to launch binding coroutine in unconfined dispatcher while still starting it undispatched. 

### Tests
This PR introduces a test that passes without f15ec672eab55c5b7a72bab60d625dfab564d33c, fails with it, and passes again after these changes.

Also, validated the core flow in internal codebase that previously crashed with latest `main`. 

Fixes #551