### PR TITLE
[Rib Worker] Specify CoroutineDispatcher for onStart/onStop and provide WorkerBinder monitoring option

### DIFF
--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compileOnly deps.apt.androidApi
     compileOnly deps.external.checkerQual
 
+    testImplementation project(":libraries:rib-coroutines-test")
     testImplementation deps.androidx.annotations
     testImplementation deps.apt.androidApi
     testImplementation deps.kotlin.stdlib

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
@@ -15,6 +15,8 @@
  */
 package com.uber.rib.core
 
+import kotlinx.coroutines.CoroutineDispatcher
+
 /**
  * Interface used when creating a manager or helper class that should be bound to an interactor's
  * lifecycle using a binder like [WorkerBinder]. The worker event is decoupled from the
@@ -22,6 +24,16 @@ package com.uber.rib.core
  * other lifecycles we're interested in.
  */
 public interface Worker {
+
+  /**
+   * Specifies in which [CoroutineDispatcher] WorkerBind.bind will be operating on
+   *
+   * NOTE: Default implementation will be using RibDispatchers.Unconfined to keep "caller" backward compatibility on existing usages
+   */
+  @JvmDefault
+  public val coroutineDispatcher: CoroutineDispatcher
+    get() = RibDispatchers.Unconfined
+
   /**
    * Called when worker is started.
    *

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -21,6 +21,7 @@ import com.uber.rib.core.lifecycle.InteractorEvent
 import com.uber.rib.core.lifecycle.PresenterEvent
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.Observable
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -28,9 +29,27 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+import kotlin.system.measureTimeMillis
 
 /** Helper class to bind to an interactor's lifecycle to translate it to a [Worker] lifecycle. */
 public object WorkerBinder {
+
+  private var workerBinderListenerWeakRef: WeakReference<WorkerBinderListener>? = null
+
+  /**
+   * Initializes reporting of [WorkerBinderInfo] via [WorkerBinderListener]
+   *
+   * IMPORTANT: This should be called only once at early app scope to get proper monitoring of early worker
+   * being bound
+   *
+   */
+  @JvmStatic
+  public fun initializeMonitoring(workerBinderListener: WorkerBinderListener) {
+    this.workerBinderListenerWeakRef =
+      WeakReference<WorkerBinderListener>(workerBinderListener)
+  }
+
   /**
    * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
    * interactor's lifecycle events. Inject this class into your interactor and call this method on
@@ -42,7 +61,7 @@ public object WorkerBinder {
    */
   @JvmStatic
   public fun bind(interactor: Interactor<*, *>, worker: Worker): WorkerUnbinder =
-    worker.bind(interactor.lifecycleFlow, Interactor.lifecycleRange)
+    worker.bind(interactor.lifecycleFlow, Interactor.lifecycleRange, workerBinderListenerWeakRef)
 
   /**
    * Bind a list of workers (ie. a manager or any other class that needs an interactor's lifecycle)
@@ -69,7 +88,7 @@ public object WorkerBinder {
    */
   @JvmStatic
   public fun bind(presenter: Presenter, worker: Worker): WorkerUnbinder =
-    worker.bind(presenter.lifecycleFlow, Presenter.lifecycleRange)
+    worker.bind(presenter.lifecycleFlow, Presenter.lifecycleRange, workerBinderListenerWeakRef)
 
   /**
    * Bind a list of workers (ie. a manager or any other class that needs an presenter's lifecycle)
@@ -88,6 +107,14 @@ public object WorkerBinder {
 
   @JvmStatic
   @VisibleForTesting
+  @Deprecated(
+    message = """
+      This method doesn't support the [WorkerBinderThreadingType] defined at Worker. Due to this, the binding
+      will happen on the caller thread without a possibility to change the threading (even specifying a different WorkerThreadingType other than CALLER_THREAD)
+      It also doesn't provide information for WorkerBinderDuration when a [WorkerDurationMonitoringListener] is added
+    """,
+    replaceWith = ReplaceWith("bind(interactor, worker) or bind(presenter, worker)")
+  )
   public fun bind(mappedLifecycle: Observable<WorkerEvent>, worker: Worker): WorkerUnbinder {
     val disposable = mappedLifecycle
       .takeWhile { it != WorkerEvent.STOP }
@@ -166,10 +193,63 @@ public object WorkerBinder {
   }
 }
 
+/**
+ * Holds all relevant information for completed Worker.onStart/onStop actions.
+ * (e.g. Name of the Worker bound, duration of total onStart/onStop, thread name where onStart/onStop happens,etc)
+ */
+public data class WorkerBinderInfo(
+  /**
+   * Worker class name
+   */
+  val workerName: String,
+
+  /**
+   * Worker event type (START/STOP)
+   */
+  val workerEvent: WorkerEvent,
+
+  /**
+   * [CoroutineDispatcher] where [WorkerBinder.bind] will be operating upon
+   */
+  val coroutineDispatcher: CoroutineDispatcher,
+
+  /**
+   * Thread name where Worker.onStart/onStop was called.
+   *
+   * e.g. When [CoroutineDispatcher] is set as [RibDispatchers.Default] a sample threadName value would be similar to `DefaultDispatcher-worker-2`
+   */
+  val threadName: String,
+
+  /**
+   * Total binding duration in milliseconds of Worker.onStart/onStop
+   */
+  val totalBindingDurationMilli: Long
+)
+
+/**
+ * Reports total binding duration of Worker.onStart/onStop
+ */
+public fun interface WorkerBinderListener {
+
+  /**
+   * Reports all related Worker information via [WorkerBinderInfo] when onStart/onStop methods are completed
+   */
+  public fun onBindCompleted(
+    workerBinderInfo: WorkerBinderInfo
+  )
+}
+
 private fun <T : Comparable<T>> Worker.bind(
   lifecycle: SharedFlow<T>,
   lifecycleRange: ClosedRange<T>,
+  workerDurationListenerWeakRef: WeakReference<WorkerBinderListener>?
 ): WorkerUnbinder {
+
+  val coroutineStart = if (coroutineDispatcher == RibDispatchers.Unconfined) {
+    CoroutineStart.UNDISPATCHED
+  } else {
+    CoroutineStart.DEFAULT
+  }
   /*
    * We need `Dispatchers.Unconfined` to react immediately to lifecycle flow emissions, and we need
    * `CoroutineStart.Undispatched` to prevent coroutines launched in `onStart` with `Dispatchers.Unconfined`
@@ -178,11 +258,50 @@ private fun <T : Comparable<T>> Worker.bind(
    * GlobalScope won't leak the job, because the flow completes when lifecycle completes.
    */
   @OptIn(DelicateCoroutinesApi::class)
-  val job = GlobalScope.launch(RibDispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+  val job = GlobalScope.launch(
+    coroutineDispatcher,
+    start = coroutineStart
+  ) {
     lifecycle
       .takeWhile { it < lifecycleRange.endInclusive }
-      .onCompletion { onStop() }
-      .collect { onStart(WorkerScopeProvider(lifecycle.asScopeProvider(lifecycleRange))) }
+      .onCompletion {
+        bindAndReportWorkerInfo(workerDurationListenerWeakRef, WorkerEvent.STOP) { onStop() }
+      }
+      .collect {
+        bindAndReportWorkerInfo(workerDurationListenerWeakRef, WorkerEvent.START) {
+          val workerScopeProvider = WorkerScopeProvider(lifecycle.asScopeProvider(lifecycleRange))
+          onStart(workerScopeProvider)
+        }
+      }
   }
   return WorkerUnbinder(job::cancel)
+}
+
+private inline fun Worker.bindAndReportWorkerInfo(
+  workerBinderListeners: WeakReference<WorkerBinderListener>?,
+  event: WorkerEvent,
+  workerBinderAction: Worker.() -> Unit
+) {
+  val duration = measureTimeMillis { workerBinderAction() }
+  workerBinderListeners?.reportWorkerBinderInfo(this, event, duration)
+}
+
+private fun WeakReference<WorkerBinderListener>.reportWorkerBinderInfo(
+  worker: Worker,
+  workerEvent: WorkerEvent,
+  totalBindingEventMilli: Long
+) {
+
+  val workerClassName = worker.javaClass.name
+  val currentThreadName = Thread.currentThread().name
+
+  val workerBinderInfo = WorkerBinderInfo(
+    workerClassName,
+    workerEvent,
+    worker.coroutineDispatcher,
+    currentThreadName,
+    totalBindingEventMilli
+  )
+
+  this@reportWorkerBinderInfo.get()?.onBindCompleted(workerBinderInfo)
 }

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.Test
+
+class WorkerTest {
+
+  @Test
+  fun threadingType_withDefaultWorker_shouldUseUnconfinedDispatchers() {
+    val defaultWorker = DefaultWorker()
+    Truth.assertThat(defaultWorker.coroutineDispatcher)
+      .isEqualTo(RibDispatchers.Unconfined)
+  }
+
+  @Test
+  fun threadingType_withBackgroundWorker_shouldUseDefaultDispatchers() {
+    val backgroundWorker = BackgroundWorker()
+    Truth.assertThat(backgroundWorker.coroutineDispatcher).isEqualTo(RibDispatchers.Default)
+  }
+
+  private class DefaultWorker : Worker
+
+  private class BackgroundWorker : Worker {
+    override val coroutineDispatcher: CoroutineDispatcher = RibDispatchers.Default
+  }
+}

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeWorker.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeWorker.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+class FakeWorker : Worker


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
# Issue

https://github.com/uber/RIBs/issues/555

# Depends on https://github.com/uber/RIBs/pull/552

# Goal

To be more explicit on the threading model where a RIB Worker.onStart/onStop will be running upon (will also include a monitoring option for Worker duration and the threading type they operate on)

**IMPORTANT: This PR only focus on updating existing production Rib Worker e.g. **com.uber.rib.core.Worker**. There is a new proposal on https://github.com/uber/RIBs/pull/547 in order to define a new RibCoroutineWorker that will run by default on background thread and will have onStart defined as a suspend function**

## Updating presidio Worker to allow specifying threading model

Worker will specify a new method in order to clarify on which thread a Worker onStart/onStop will be running upon 

Default implementation of this new method will be of  WORKER_BINDER_CALLER thread type in order to keep existing WorkerBind.bind as it (often times WorkerBinder.bind is called on UI thread)

```
@JvmDefault
public val coroutineDispatcher: CoroutineDispatcher
  get() = RibDispatchers.Unconfined
```

```
class FileCreationWorker: Worker {

 override val coroutineDispatcher: CoroutineDispatcher = RibDispatchers.IO

  override fun onStart(lifecycle: WorkerScopeProvider) {
     // Expensive IO operation here
  }

  override fun onStop() {
    // Also running on IO
  }
}
```

## Updating existing WorkerBinder.bind() internals

Update WorkerBinder internal methods to ensure onStart/onStop will happen on the specified Worker.threadingType()

Also a `RibWorkerBinderDurationListener` can be specified at `WorkerBinder` in order to get total binding duration of Worker.onStart/Worker.onStop

## Monitoring

Will provide monitoring mechanism to report total duration of Worker.onStart/onStop and which Threading type are they operating upon.

Sample reporting data for a sample expensive Worker

![image](https://user-images.githubusercontent.com/4230063/233266303-70134677-16be-4160-afc5-ebe0b73bb0bb.png)


Reporting data will be something similar to this

```
data class BinderDuration(
  /**
   * Worker class name
   */
  val workerName: String,

  /**
   * Worker event type (START/STOP)
   */
  val workerEvent: WorkerEvent,

  /**
   * Threading Type where Worker will operate
   */
  val threadingType: ThreadingType,

  /**
   * Thread name where Worker.onStart/onStop was called
   */
  val threadName: String,

  /**
   * Total binding duration in milli of Worker.onStart/onStop
   */
  val totalBindingDurationMilli: Long
)
```

## Test plan + Verification

Tested WorkerBinder on Interactor's/Presenter by validating on demo libs. (Pending to add demo videos)

https://user-images.githubusercontent.com/4230063/233267153-81bf6c9f-176b-4604-8986-e2df1fbf3c64.mov


<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
