### PR TITLE
enable explicit api mode for kotlin libraries

### DIFF
--- a/android/libraries/rib-android-compose/build.gradle
+++ b/android/libraries/rib-android-compose/build.gradle
@@ -53,3 +53,7 @@ dependencies {
     testImplementation deps.test.mockitoKotlin
     testImplementation project(":libraries:rib-test")
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-android-core/build.gradle
+++ b/android/libraries/rib-android-core/build.gradle
@@ -47,3 +47,7 @@ dependencies {
     testImplementation deps.androidx.appcompat
     testImplementation deps.external.roboelectricBase
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-android/build.gradle
+++ b/android/libraries/rib-android/build.gradle
@@ -57,3 +57,7 @@ dependencies {
     testImplementation deps.test.mockitoKotlin
     testImplementation project(":libraries:rib-test")
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-compiler-app/build.gradle
+++ b/android/libraries/rib-compiler-app/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     testImplementation deps.test.compileTesting
 }
 
+kotlin {
+    explicitApi()
+}
+
 // https://code.google.com/p/android/issues/detail?id=64887
 task copyTestResources(type: Copy) {
     from "${projectDir}/src/test/resources"

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/AnnotatedClass.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/AnnotatedClass.kt
@@ -18,9 +18,9 @@ package com.uber.rib.compiler
 import javax.lang.model.element.TypeElement
 
 /** Information to a class.  */
-open abstract class AnnotatedClass(
+public abstract class AnnotatedClass(
   /** @return the type element that this wraps. */
-  open val typeElement: TypeElement
+  public open val typeElement: TypeElement
 ) {
 
   /**
@@ -29,13 +29,13 @@ open abstract class AnnotatedClass(
    *
    * @return the root name.
    */
-  open val rootName: String by lazy {
+  public open val rootName: String by lazy {
     typeElement.simpleName.toString().substringBefore(nameSuffix)
   }
 
   /** Set if code has been generated. */
-  open var isCodeGenerated = false
+  public open var isCodeGenerated: Boolean = false
 
   /** @return the annotated class name suffix */
-  abstract val nameSuffix: String
+  public abstract val nameSuffix: String
 }

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/CompilerUtils.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/CompilerUtils.kt
@@ -19,14 +19,14 @@ import javax.lang.model.element.Element
 import javax.lang.model.element.PackageElement
 
 /** Handy functions for generating code.  */
-open class CompilerUtils {
-  companion object {
+public open class CompilerUtils {
+  public companion object {
     /**
      * Returns the name of the package that the given type is in. If the type is in the default
      * (unnamed) package then the name is the empty string.
      */
     @JvmStatic
-    fun packageNameOf(type: Element): String {
+    public fun packageNameOf(type: Element): String {
       var type = type
       while (true) {
         val enclosing = type.enclosingElement

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/Constants.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/Constants.kt
@@ -16,9 +16,9 @@
 package com.uber.rib.compiler
 
 /** Constant values used by the annotation processor.  */
-open class Constants {
-  companion object {
+public open class Constants {
+  public companion object {
     /** {@inheritDoc}  */
-    const val INTERACTOR_SUFFIX = "Interactor"
+    public const val INTERACTOR_SUFFIX: String = "Interactor"
   }
 }

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ErrorReporter.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ErrorReporter.kt
@@ -20,7 +20,7 @@ import javax.lang.model.element.Element
 import javax.tools.Diagnostic
 
 /** Holds utilities for reporting errors.  */
-open class ErrorReporter(private val messager: Messager) {
+public open class ErrorReporter(private val messager: Messager) {
   @JvmOverloads
   internal open fun reportError(message: CharSequence, element: Element? = null) {
     messager.printMessage(Diagnostic.Kind.ERROR, message, element)

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/Generator.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/Generator.kt
@@ -23,7 +23,7 @@ import javax.annotation.processing.ProcessingEnvironment
  *
  * @param <T> the [AnnotatedClass] that the [Generator.generate] needs.
  */
-abstract class Generator<T : AnnotatedClass>(
+public abstract class Generator<T : AnnotatedClass>(
   protected val processingEnvironment: ProcessingEnvironment,
   protected val errorReporter: ErrorReporter
 ) {
@@ -35,5 +35,5 @@ abstract class Generator<T : AnnotatedClass>(
    * @throws IOException when something goes wrong.
    */
   @Throws(IOException::class)
-  abstract fun generate(builder: T)
+  public abstract fun generate(builder: T)
 }

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/InteractorAnnotatedClass.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/InteractorAnnotatedClass.kt
@@ -18,12 +18,12 @@ package com.uber.rib.compiler
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 
-open class InteractorAnnotatedClass(
+public open class InteractorAnnotatedClass(
   typeElement: TypeElement,
   /** @return the list of dependencies. */
-  open val dependencies: List<VariableElement>,
+  public open val dependencies: List<VariableElement>,
   /** @return Whether this interactor extends BasicInteractor.  */
-  open val isBasic: Boolean
+  public open val isBasic: Boolean
 ) : AnnotatedClass(typeElement) {
 
   open override val nameSuffix: String

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ProcessContext.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ProcessContext.kt
@@ -22,13 +22,13 @@ import javax.lang.model.util.Types
  * The interface defines the context that shared across [ProcessorPipeline] during annotation
  * processing.
  */
-interface ProcessContext {
+public interface ProcessContext {
   /** @return the [ErrorReporter] */
-  val errorReporter: ErrorReporter?
+  public val errorReporter: ErrorReporter?
 
   /** @return the [Elements] */
-  val elementUtils: Elements?
+  public val elementUtils: Elements?
 
   /** @return the [Types] */
-  val typesUtils: Types?
+  public val typesUtils: Types?
 }

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ProcessorPipeline.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/ProcessorPipeline.kt
@@ -21,20 +21,20 @@ import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
 /** The processor pipeline that processes one specific annotation.  */
-abstract class ProcessorPipeline(protected var processContext: ProcessContext) {
+public abstract class ProcessorPipeline(protected var processContext: ProcessContext) {
   protected var errorReporter: ErrorReporter? = processContext.errorReporter
   protected var elementUtils: Elements? = processContext.elementUtils
   protected var typesUtils: Types? = processContext.typesUtils
 
   /** Process the annotation that is the same as processor */
   @Throws(Throwable::class)
-  fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
+  public fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
     processAnnotations(annotations, roundEnv)
     return false
   }
 
   /** @return the annotation that this Processor pipeline works on. */
-  abstract val annotationType: Class<out Annotation>
+  public abstract val annotationType: Class<out Annotation>
 
   /** Processes the annotation. */
   @Throws(Throwable::class)

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/RibInteractorProcessorPipeline.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/RibInteractorProcessorPipeline.kt
@@ -21,7 +21,7 @@ import java.util.ArrayList
 import javax.lang.model.element.TypeElement
 
 /** The processor pipeline for [RibInteractor]  */
-open class RibInteractorProcessorPipeline(
+public open class RibInteractorProcessorPipeline(
   processContext: ProcessContext,
   private var interactorGenerator: Generator<InteractorAnnotatedClass>?
 ) : TypeProcessorPipeline(processContext) {
@@ -68,9 +68,9 @@ open class RibInteractorProcessorPipeline(
     }
   }
 
-  companion object {
+  public companion object {
     @JvmField
-    val SUPPORT_ANNOTATION_TYPE: Class<RibInteractor> = RibInteractor::class.java
+    public val SUPPORT_ANNOTATION_TYPE: Class<RibInteractor> = RibInteractor::class.java
   }
 
   /**

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/RibProcessor.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/RibProcessor.kt
@@ -25,7 +25,7 @@ import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
 /** Process the annotations with [ProcessorPipeline].  */
-abstract class RibProcessor : AbstractProcessor(), ProcessContext {
+public abstract class RibProcessor : AbstractProcessor(), ProcessContext {
 
   override var errorReporter: ErrorReporter? = null
     protected set
@@ -34,7 +34,7 @@ abstract class RibProcessor : AbstractProcessor(), ProcessContext {
   override var typesUtils: Types? = null
     protected set
 
-  var processorPipelines: MutableList<ProcessorPipeline> = ArrayList()
+  public var processorPipelines: MutableList<ProcessorPipeline> = ArrayList()
 
   @Synchronized
   override fun init(processingEnv: ProcessingEnvironment) {

--- a/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/TypeProcessorPipeline.kt
+++ b/android/libraries/rib-compiler-app/src/main/kotlin/com/uber/rib/compiler/TypeProcessorPipeline.kt
@@ -21,7 +21,7 @@ import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
 
 /** Base ProcessorPipeline that parses the annotated elements as type element.  */
-abstract class TypeProcessorPipeline(
+public abstract class TypeProcessorPipeline(
   processContext: ProcessContext
 ) : ProcessorPipeline(processContext) {
   /**

--- a/android/libraries/rib-debug-utils/build.gradle
+++ b/android/libraries/rib-debug-utils/build.gradle
@@ -23,3 +23,7 @@ targetCompatibility = deps.build.javaVersion.toString()
 dependencies {
     implementation project(":libraries:rib-base")
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
+++ b/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
@@ -16,7 +16,7 @@
 package com.uber.rib.core
 
 /** Debugging utilities when working with Routers.  */
-object RouterDebugUtils {
+public object RouterDebugUtils {
   private const val ARM_RIGHT = "└── "
   private const val INTERSECTION = "├── "
   private const val LINE = "│   "
@@ -31,7 +31,7 @@ object RouterDebugUtils {
    */
   @JvmStatic
   @JvmOverloads
-  fun printRouterSubtree(router: Router<*>, prefix: String = "", isTail: Boolean = true) {
+  public fun printRouterSubtree(router: Router<*>, prefix: String = "", isTail: Boolean = true) {
     Rib.getConfiguration()
       .handleDebugMessage(prefix + (if (isTail) ARM_RIGHT else INTERSECTION) + router.tag)
     val children = router.getChildren()

--- a/android/libraries/rib-router-navigator/build.gradle
+++ b/android/libraries/rib-router-navigator/build.gradle
@@ -33,3 +33,7 @@ dependencies {
     testImplementation deps.test.mockitoKotlin
     testImplementation deps.test.truth
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigator.kt
@@ -25,9 +25,9 @@ import org.checkerframework.checker.guieffect.qual.UIEffect
  *
  * @param <StateT> type of state to switch on.
  */
-interface RouterNavigator<StateT : RouterNavigatorState> {
+public interface RouterNavigator<StateT : RouterNavigatorState> {
   /** Determine how pushes will affect the stack  */
-  enum class Flag {
+  public enum class Flag {
     /** Push a new state to the top of the navigation stack.  */
     DEFAULT,
 
@@ -72,7 +72,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
   }
 
   /** Pop the current state and rewind to the previous state (if there is a previous state).  */
-  fun popState()
+  public fun popState()
 
   /**
    * Switch to a new state - this will switch out children if the state is not the current active
@@ -87,7 +87,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param detachTransition method to clean up child router when removed.
    * @param <R> router type to detach.
    </R> */
-  fun <R : Router<*>> pushState(
+  public fun <R : Router<*>> pushState(
     newState: StateT,
     attachTransition: AttachTransition<R, StateT>,
     detachTransition: DetachTransition<R, StateT>?
@@ -107,7 +107,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param detachTransition method to clean up child router when removed.
    * @param <R> router type to detach.
    </R> */
-  fun <R : Router<*>> pushState(
+  public fun <R : Router<*>> pushState(
     newState: StateT,
     flag: Flag,
     attachTransition: AttachTransition<R, StateT>,
@@ -131,7 +131,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <R> router type to detach.
    </R> */
   @Deprecated("")
-  fun <R : Router<*>> pushRetainedState(
+  public fun <R : Router<*>> pushRetainedState(
     newState: StateT,
     attachTransition: AttachTransition<R, StateT>,
     detachTransition: DetachTransition<R, StateT>?
@@ -153,7 +153,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <R> [Router] type.
    </R> */
   @Deprecated("")
-  fun <R : Router<*>> pushRetainedState(
+  public fun <R : Router<*>> pushRetainedState(
     newState: StateT,
     attachTransition: AttachTransition<R, StateT>
   )
@@ -174,7 +174,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <R> router type to detach.
    </R> */
   @Deprecated("")
-  fun <R : Router<*>> pushTransientState(
+  public fun <R : Router<*>> pushTransientState(
     newState: StateT,
     attachTransition: AttachTransition<R, StateT>,
     detachTransition: DetachTransition<R, StateT>?
@@ -195,7 +195,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <R> [Router] type.
    </R> */
   @Deprecated("")
-  fun <R : Router<*>> pushTransientState(
+  public fun <R : Router<*>> pushTransientState(
     newState: StateT,
     attachTransition: AttachTransition<R, StateT>
   )
@@ -205,14 +205,14 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    *
    * @return the top [Router] on the stack.
    */
-  fun peekRouter(): Router<*>?
+  public fun peekRouter(): Router<*>?
 
   /**
    * Peek the top [StateT] on the stack.
    *
    * @return the top [StateT] on the stack.
    */
-  fun peekState(): StateT?
+  public fun peekState(): StateT?
 
   /**
    * Gets the size of the navigation stack.
@@ -220,26 +220,26 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @return Size of the navigation stack.
    */
   @IntRange(from = 0)
-  fun size(): Int
+  public fun size(): Int
 
   /**
    * Must be called when host interactor is going to detach. This will pop the current active router
    * and clear the entire stack.
    */
-  fun hostWillDetach()
+  public fun hostWillDetach()
 
   /**
    * Allows consumers to write custom attachment logic when switching states.
    *
    * @param <StateT> state type.
    </StateT> */
-  interface AttachTransition<RouterT : Router<*>, StateT : RouterNavigatorState> {
+  public interface AttachTransition<RouterT : Router<*>, StateT : RouterNavigatorState> {
     /**
      * Constructs a new [RouterT] instance. This will only be called once.
      *
      * @return the newly attached child router.
      */
-    fun buildRouter(): RouterT
+    public fun buildRouter(): RouterT
 
     /**
      * Prepares the router for a state transition. [StackRouterNavigator] will handling
@@ -250,7 +250,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
      * @param newState state the navigator is transitioning to.
      */
     @UIEffect
-    fun willAttachToHost(
+    public fun willAttachToHost(
       router: RouterT,
       previousState: StateT?,
       newState: StateT,
@@ -265,7 +265,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <RouterT> [RouterT]
    * @param <StateT> [StateT]
    </StateT></RouterT> */
-  abstract class DetachCallback<RouterT : Router<*>, StateT : RouterNavigatorState> : DetachTransition<RouterT, StateT> {
+  public abstract class DetachCallback<RouterT : Router<*>, StateT : RouterNavigatorState> : DetachTransition<RouterT, StateT> {
     override fun willDetachFromHost(
       router: RouterT,
       previousState: StateT,
@@ -280,7 +280,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
      * @param router [Router]
      * @param newState [StateT]
      */
-    open fun onPostDetachFromHost(router: RouterT, newState: StateT?, isPush: Boolean) {}
+    public open fun onPostDetachFromHost(router: RouterT, newState: StateT?, isPush: Boolean) {}
   }
 
   /**
@@ -290,7 +290,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
    * @param <StateT> state type.
    </StateT></RouterT> */
   @PolyUIType
-  interface DetachTransition<RouterT : Router<*>, StateT : RouterNavigatorState> {
+  public interface DetachTransition<RouterT : Router<*>, StateT : RouterNavigatorState> {
     /**
      * Notifies consumer that [StackRouterNavigator] is going to detach this router. Consumers
      * should remove any views and perform any required cleanup.
@@ -300,7 +300,7 @@ interface RouterNavigator<StateT : RouterNavigatorState> {
      * @param newState state the navigator is transition in to (if any).
      */
     @PolyUIEffect
-    fun willDetachFromHost(
+    public fun willDetachFromHost(
       router: RouterT,
       previousState: StateT,
       newState: StateT?,

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvent.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvent.kt
@@ -16,13 +16,13 @@
 package com.uber.rib.core
 
 /** Event which is triggered when [StackRouterNavigator] is used to navigate between routers. */
-open class RouterNavigatorEvent(
+public open class RouterNavigatorEvent(
   /** @return the [RouterNavigatorEventType] */
-  open val eventType: RouterNavigatorEventType,
+  public open val eventType: RouterNavigatorEventType,
 
   /** @return the instance of Parent [Router] */
-  open val parentRouter: Router<*>,
+  public open val parentRouter: Router<*>,
 
   /** @return the instance of child [Router] */
-  open val router: Router<*>
+  public open val router: Router<*>
 )

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEventType.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEventType.kt
@@ -18,6 +18,6 @@ package com.uber.rib.core
 /**
  * Enum consisting of event types that occur when [RouterNavigator] is used for transition.
  */
-enum class RouterNavigatorEventType {
+public enum class RouterNavigatorEventType {
   WILL_ATTACH_TO_HOST
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorEvents.kt
@@ -21,12 +21,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.rx2.asObservable
 
 /** Class that provides its instance to emit or subscribe to [RouterNavigatorEvent]  */
-class RouterNavigatorEvents private constructor() {
+public class RouterNavigatorEvents private constructor() {
 
   private val _events = MutableSharedFlow<RouterNavigatorEvent>(0, 1, BufferOverflow.DROP_OLDEST)
 
   /** @return the stream which can be subcribed to listen for [RouterNavigatorEvent] */
-  val events: Observable<RouterNavigatorEvent> = _events.asObservable()
+  public val events: Observable<RouterNavigatorEvent> = _events.asObservable()
 
   @JvmSynthetic // Hide from Java consumers. In Java, `getEvents` resolves to the `events` property.
   @JvmName("_getEvents")
@@ -43,13 +43,13 @@ class RouterNavigatorEvents private constructor() {
    * @param parent router instance to which child will attach to.
    * @param child router instance which getting attached.
    */
-  fun emitEvent(eventType: RouterNavigatorEventType, parent: Router<*>, child: Router<*>) {
+  public fun emitEvent(eventType: RouterNavigatorEventType, parent: Router<*>, child: Router<*>) {
     _events.tryEmit(RouterNavigatorEvent(eventType, parent, child))
   }
 
-  companion object {
+  public companion object {
     /** @return the singleton instance */
     @JvmStatic
-    val instance = RouterNavigatorEvents()
+    public val instance: RouterNavigatorEvents = RouterNavigatorEvents()
   }
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorFactory.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorFactory.kt
@@ -24,7 +24,7 @@ package com.uber.rib.core
  *
  * @param creationStrategy [Strategy] `null` for the default strategy.
  */
-class RouterNavigatorFactory(private val creationStrategy: Strategy?) {
+public class RouterNavigatorFactory(private val creationStrategy: Strategy?) {
   /**
    * Generate a new [RouterNavigator].
    *
@@ -32,12 +32,12 @@ class RouterNavigatorFactory(private val creationStrategy: Strategy?) {
    * @param <StateT> [StateT] type for the [RouterNavigator]
    * @return A new [RouterNavigator]
    */
-  open fun <StateT : RouterNavigatorState> create(hostRouter: Router<*>): RouterNavigator<StateT> {
+  public open fun <StateT : RouterNavigatorState> create(hostRouter: Router<*>): RouterNavigator<StateT> {
     return creationStrategy?.create(hostRouter) ?: StackRouterNavigator(hostRouter)
   }
 
   /** Strategy to employ when using this factory to generate new [RouterNavigator]s.  */
-  interface Strategy {
+  public interface Strategy {
     /**
      * Generate a new [RouterNavigator].
      *
@@ -45,6 +45,6 @@ class RouterNavigatorFactory(private val creationStrategy: Strategy?) {
      * @param <StateT> [StateT] type for the [RouterNavigator]
      * @return A new [RouterNavigator]
      */
-    fun <StateT : RouterNavigatorState> create(hostRouter: Router<*>): RouterNavigator<StateT>
+    public fun <StateT : RouterNavigatorState> create(hostRouter: Router<*>): RouterNavigator<StateT>
   }
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
@@ -16,11 +16,11 @@
 package com.uber.rib.core
 
 /** Represents states for [StackRouterNavigator]. Most often implemented with an enum. */
-interface RouterNavigatorState {
+public interface RouterNavigatorState {
 
   /** @return identifier for a [StackRouterNavigator] state. */
   @JvmDefault
-  fun stateName(): String {
+  public fun stateName(): String {
     return if (this.javaClass.isEnum) {
       (this as Enum<*>).name
     } else {
@@ -40,5 +40,5 @@ interface RouterNavigatorState {
    * [RouterNavigator.AttachTransition]
    */
   @JvmDefault
-  fun isCacheable(): Boolean = false
+  public fun isCacheable(): Boolean = false
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
@@ -27,7 +27,7 @@ import java.util.Locale
  * @param hostRouter Host router
  * @param forceRouterCaching Override [RouterNavigatorState.isCacheable] behavior
  */
-open class StackRouterNavigator<StateT : RouterNavigatorState>
+public open class StackRouterNavigator<StateT : RouterNavigatorState>
 @JvmOverloads
 constructor(
   private val hostRouter: Router<*>,
@@ -195,7 +195,7 @@ constructor(
    *
    * NOTE: This must be called when host interactor is going to detach.
    */
-  open fun detachAll() {
+  public open fun detachAll() {
     log(
       String.format(
         Locale.getDefault(), "Detaching RouterNavigator from host -> %s", hostRouterName
@@ -389,7 +389,7 @@ constructor(
     detachAll()
   }
 
-  companion object {
+  public companion object {
     /** Writes out to the debug log.  */
     private fun log(text: String) {
       Rib.getConfiguration().handleDebugMessage("%s: $text", "RouterNavigator")

--- a/android/libraries/rib-screen-stack-base/build.gradle
+++ b/android/libraries/rib-screen-stack-base/build.gradle
@@ -42,3 +42,7 @@ dependencies {
     implementation deps.kotlin.coroutinesAndroid
     implementation deps.kotlin.coroutinesRx2
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-test/build.gradle
+++ b/android/libraries/rib-test/build.gradle
@@ -29,3 +29,7 @@ dependencies {
     api deps.test.mockito
     implementation deps.test.mockitoKotlin
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/AndroidRecordingRx2Observer.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/AndroidRecordingRx2Observer.kt
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit
  *
  * @param <T> Parametrized type.
  */
-open class AndroidRecordingRx2Observer<T : Any> : Observer<T> {
+public open class AndroidRecordingRx2Observer<T : Any> : Observer<T> {
   private val events: BlockingDeque<Any> = LinkedBlockingDeque()
 
   override fun onSubscribe(disposable: Disposable) {}
@@ -45,12 +45,12 @@ open class AndroidRecordingRx2Observer<T : Any> : Observer<T> {
     events.addLast(OnNext(t))
   }
 
-  open fun takeNext(): T {
+  public open fun takeNext(): T {
     val event: OnNext = takeEvent(OnNext::class.java)
     return event.value as T
   }
 
-  open fun takeError(): Throwable {
+  public open fun takeError(): Throwable {
     val event: OnError = takeEvent(OnError::class.java)
     return event.throwable
   }
@@ -65,7 +65,7 @@ open class AndroidRecordingRx2Observer<T : Any> : Observer<T> {
     return event as E
   }
 
-  open fun assertNoMoreEvents() {
+  public open fun assertNoMoreEvents() {
     try {
       val event: Any = takeEvent(Any::class.java)
       throw IllegalStateException("Expected no more events but got $event")

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeComponent.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeComponent.kt
@@ -15,7 +15,7 @@
  */
 package com.uber.rib.core
 
-class FakeComponent<P : Presenter, T : Interactor<P, *>> private constructor(
+public class FakeComponent<P : Presenter, T : Interactor<P, *>> private constructor(
   private val presenter: P
 ) : InteractorComponent<P, T> {
 
@@ -25,9 +25,9 @@ class FakeComponent<P : Presenter, T : Interactor<P, *>> private constructor(
     return presenter
   }
 
-  companion object {
+  public companion object {
     @JvmStatic
-    fun <T : Interactor<FakePresenter, *>> withFakePresenterFor(interactorClass: Class<T>): FakeComponent<FakePresenter, T> {
+    public fun <T : Interactor<FakePresenter, *>> withFakePresenterFor(interactorClass: Class<T>): FakeComponent<FakePresenter, T> {
       return FakeComponent(FakePresenter())
     }
   }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
@@ -16,14 +16,14 @@
 package com.uber.rib.core
 
 @SuppressWarnings("RibInteractorOnIteractor")
-open class FakeInteractor<P : Any, R : Router<*>> : Interactor<P, R>() {
-  open fun attach() {
+public open class FakeInteractor<P : Any, R : Router<*>> : Interactor<P, R>() {
+  public open fun attach() {
     actualPresenter = FakePresenter() as P
     router = FakeRouter(this) as R
     dispatchAttach(null)
   }
 
-  open fun detach() {
+  public open fun detach() {
     dispatchDetach()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakePresenter.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakePresenter.kt
@@ -15,4 +15,4 @@
  */
 package com.uber.rib.core
 
-class FakePresenter : Presenter()
+public class FakePresenter : Presenter()

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeRouter.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeRouter.kt
@@ -20,9 +20,9 @@ package com.uber.rib.core
  *
  * @param <I>
  */
-class FakeRouter<I : Interactor<*, *>> : Router<I> {
-  constructor(interactor: I) : super(interactor)
-  constructor(interactor: I, ribRefWatcher: RibRefWatcher, mainThread: Thread) : super(null, interactor, ribRefWatcher, mainThread)
+public class FakeRouter<I : Interactor<*, *>> : Router<I> {
+  public constructor(interactor: I) : super(interactor)
+  public constructor(interactor: I, ribRefWatcher: RibRefWatcher, mainThread: Thread) : super(null, interactor, ribRefWatcher, mainThread)
 
   override fun attachToInteractor() {
     // do not automatically attach this

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
@@ -21,7 +21,7 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verify
 
 /** The helper to test [Interactor].  */
-object InteractorHelper {
+public object InteractorHelper {
   /**
    * Attaches the [Interactor] using a mock router.
    *
@@ -33,7 +33,7 @@ object InteractorHelper {
    * @param savedInstanceState the saved [Bundle].
    */
   @JvmStatic
-  open fun <P : Any, R : Router<*>> attach(
+  public fun <P : Any, R : Router<*>> attach(
     interactor: Interactor<P, R>,
     presenter: P,
     router: R,
@@ -51,7 +51,7 @@ object InteractorHelper {
    * @param savedInstanceState the saved [Bundle].
    */
   @JvmStatic
-  open fun reattach(interactor: Interactor<*, *>, savedInstanceState: Bundle?) {
+  public fun reattach(interactor: Interactor<*, *>, savedInstanceState: Bundle?) {
     interactor.dispatchAttach(savedInstanceState)
   }
 
@@ -61,7 +61,7 @@ object InteractorHelper {
    * @param controller the [Interactor].
    */
   @JvmStatic
-  open fun detach(controller: Interactor<*, *>) {
+  public fun detach(controller: Interactor<*, *>) {
     controller.dispatchDetach()
   }
 
@@ -71,7 +71,7 @@ object InteractorHelper {
    * @param interactor the [Interactor].
    */
   @JvmStatic
-  open fun verifyAttached(interactor: Interactor<*, *>) {
+  public fun verifyAttached(interactor: Interactor<*, *>) {
     verify(interactor).dispatchAttach(or(isNull(), isA<Bundle>()))
   }
 
@@ -81,7 +81,7 @@ object InteractorHelper {
    * @param interactor the [Interactor].
    */
   @JvmStatic
-  open fun verifyDetached(interactor: Interactor<*, *>) {
+  public fun verifyDetached(interactor: Interactor<*, *>) {
     verify(interactor).dispatchDetach()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/PresenterHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/PresenterHelper.kt
@@ -16,14 +16,14 @@
 package com.uber.rib.core
 
 /** The helper to test [Presenter].  */
-object PresenterHelper {
+public object PresenterHelper {
   /**
    * Loads the given [Presenter].
    *
    * @param presenter the presenter.
    */
   @JvmStatic
-  open fun load(presenter: Presenter) {
+  public fun load(presenter: Presenter) {
     presenter.dispatchLoad()
   }
 
@@ -33,7 +33,7 @@ object PresenterHelper {
    * @param presenter the presenter.
    */
   @JvmStatic
-  open fun unload(presenter: Presenter) {
+  public fun unload(presenter: Presenter) {
     presenter.dispatchUnload()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RibTestBasePlaceholder.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RibTestBasePlaceholder.kt
@@ -15,4 +15,4 @@
  */
 package com.uber.rib.core
 
-open class RibTestBasePlaceholder
+public open class RibTestBasePlaceholder

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RouterHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/RouterHelper.kt
@@ -27,7 +27,7 @@ import org.mockito.kotlin.verify
 import org.mockito.verification.VerificationMode
 
 /** The helper to test [Router].  */
-object RouterHelper {
+public object RouterHelper {
   /**
    * Dispatches attachment to a router.
    *
@@ -35,7 +35,7 @@ object RouterHelper {
    * @param <R> type of router.
    */
   @JvmStatic
-  open fun <R : Router<*>> attach(router: R) {
+  public fun <R : Router<*>> attach(router: R) {
     router.dispatchAttach(null)
   }
 
@@ -45,7 +45,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun detach(router: Router<*>) {
+  public fun detach(router: Router<*>) {
     router.dispatchDetach()
   }
 
@@ -55,7 +55,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyAttached(router: Router<*>) {
+  public fun verifyAttached(router: Router<*>) {
     verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
@@ -66,7 +66,7 @@ object RouterHelper {
    * @param times the number of times attached
    */
   @JvmStatic
-  open fun verifyAttached(router: Router<*>, times: Int) {
+  public fun verifyAttached(router: Router<*>, times: Int) {
     verify(router, times(times)).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
@@ -77,7 +77,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyAttached(order: InOrder, router: Router<*>) {
+  public fun verifyAttached(order: InOrder, router: Router<*>) {
     order.verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
@@ -88,7 +88,7 @@ object RouterHelper {
    * @param tag the expected tag.
    */
   @JvmStatic
-  open fun verifyAttached(router: Router<*>, tag: String) {
+  public fun verifyAttached(router: Router<*>, tag: String) {
     verify(router).dispatchAttach(or(isNull(), isA<Bundle>()), eq(tag))
   }
 
@@ -99,7 +99,7 @@ object RouterHelper {
    * @param mode The mockito verification mode. ie. `times(1)`.
    */
   @JvmStatic
-  open fun verifyAttached(router: Router<*>, mode: VerificationMode) {
+  public fun verifyAttached(router: Router<*>, mode: VerificationMode) {
     verify(router, mode).dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
 
@@ -109,7 +109,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyNotAttached(router: Router<*>) {
+  public fun verifyNotAttached(router: Router<*>) {
     verify(router, never())
       .dispatchAttach(or(isNull(), isA<Bundle>()), any())
   }
@@ -120,7 +120,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyDetached(router: Router<*>) {
+  public fun verifyDetached(router: Router<*>) {
     verify(router).dispatchDetach()
   }
 
@@ -131,7 +131,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyDetached(order: InOrder, router: Router<*>) {
+  public fun verifyDetached(order: InOrder, router: Router<*>) {
     order.verify(router).dispatchDetach()
   }
 
@@ -142,7 +142,7 @@ object RouterHelper {
    * @param mode The mockito verification mode. ie. `times(1)`.
    */
   @JvmStatic
-  open fun verifyDetached(router: Router<*>, mode: VerificationMode) {
+  public fun verifyDetached(router: Router<*>, mode: VerificationMode) {
     verify(router, mode).dispatchDetach()
   }
 
@@ -152,7 +152,7 @@ object RouterHelper {
    * @param router the [Router].
    */
   @JvmStatic
-  open fun verifyNotDetached(router: Router<*>) {
+  public fun verifyNotDetached(router: Router<*>) {
     verify(router, never()).dispatchDetach()
   }
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/WorkerHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/WorkerHelper.kt
@@ -19,7 +19,7 @@ import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.Observable
 
 /** Helper to unit test [Worker] instances.  */
-object WorkerHelper {
+public object WorkerHelper {
   /**
    * Creates a [WorkerScopeProvider] that can be driven by a test observable.
    *
@@ -27,7 +27,7 @@ object WorkerHelper {
    * @return a [WorkerScopeProvider].
    */
   @JvmStatic
-  open fun createScopeProvider(lifecycle: Observable<WorkerEvent>): WorkerScopeProvider {
+  public fun createScopeProvider(lifecycle: Observable<WorkerEvent>): WorkerScopeProvider {
     return WorkerScopeProvider(lifecycle)
   }
 }

--- a/android/libraries/rib-workflow-test/build.gradle
+++ b/android/libraries/rib-workflow-test/build.gradle
@@ -48,3 +48,7 @@ dependencies {
     implementation deps.kotlin.stdlib
     implementation deps.test.truth
 }
+
+kotlin {
+    explicitApi()
+}

--- a/android/libraries/rib-workflow/build.gradle
+++ b/android/libraries/rib-workflow/build.gradle
@@ -45,3 +45,7 @@ dependencies {
     testImplementation deps.test.truth
     testImplementation deps.test.mockito
 }
+
+kotlin {
+    explicitApi()
+}


### PR DESCRIPTION
This pull request follows the example of https://github.com/uber/RIBs/pull/548 and satisfies https://github.com/uber/RIBs/issues/545 by enabling the explicit api mode for the following modules:
* rib-debug-utils
* rib-router-navigator
* rib-test
* rib-compiler-app
* rib-android-compose
* rib-android-code
* rib-android
* rib-screen-stack-base
* rib-workflow-test
* rib-workflow