### PR TITLE
Use Kotlin contracts to remove `var` and `!!` usage in `RibCoroutineWorker`

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
@@ -16,6 +16,17 @@
 package com.uber.rib.core
 
 import com.uber.autodispose.coroutinesinterop.asScopeProvider
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,32 +41,23 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.coroutines.coroutineContext
-import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
-import kotlin.coroutines.intrinsics.intercepted
-import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
-import kotlin.coroutines.resume
 
 /** A manager or helper class bound to a [CoroutineScope] by using a binder like [bind]. */
 public fun interface RibCoroutineWorker {
   /** Called when worker is started. Children coroutines can be launched in [scope]. */
   public suspend fun onStart(scope: CoroutineScope)
 
-  /** Called when the worker is stopped with the given [cause]. Should be fast, non-blocking and should not throw. */
-  @JvmDefault
-  public fun onStop(cause: Throwable) {}
+  /** Called when worker is stopped with [cause]. Should be fast, be non-blocking and not throw. */
+  @JvmDefault public fun onStop(cause: Throwable) {}
 }
 
 // ---- Binder ---- //
 
 /**
- * A handle to interact with [RibCoroutineWorker] binding job. This handle implements [Job], which refers to the
- * completion of [RibCoroutineWorker.onStart]. It can be [joined][join] to make sure `onStart` finished. Note that
- * children coroutines launched in the [CoroutineScope] passed on to `onStart` are not waited: worker is considered
- * bound when `onStart` finishes.
+ * A handle to interact with [RibCoroutineWorker] binding job. This handle implements [Job], which
+ * refers to the completion of [RibCoroutineWorker.onStart]. It can be [joined][join] to make sure
+ * `onStart` finished. Note that children coroutines launched in the [CoroutineScope] passed on to
+ * `onStart` are not waited: worker is considered bound when `onStart` finishes.
  */
 public sealed interface BindWorkerHandle : Job {
   /** Unbinds the worker. */
@@ -75,18 +77,19 @@ private class BindWorkerHandleImpl(
 /**
  * Binds [worker] in a scope that is a child of the [CoroutineScope] receiver.
  *
- * The binding operation runs [RibCoroutineWorker.onStart] in a context inherited from the [CoroutineScope] receiver, but
- * with additional [context] elements that is, by default, [RibDispatchers.Default]. This makes the worker run on the
- * default dispatcher by default. Pass in [EmptyCoroutineContext] instead if you want the worker to not override the
- * dispatcher in the scope (if any), or pass in a custom dispatcher as [context] to specify a different dispatcher. If
+ * The binding operation runs [RibCoroutineWorker.onStart] in a context inherited from the
+ * [CoroutineScope] receiver, but with additional [context] elements that is, by default,
+ * [RibDispatchers.Default]. This makes the worker run on the default dispatcher by default. Pass in
+ * [EmptyCoroutineContext] instead if you want the worker to not override the dispatcher in the
+ * scope (if any), or pass in a custom dispatcher as [context] to specify a different dispatcher. If
  * there is no dispatcher in [CoroutineScope] nor in [context], [RibDispatchers.Default] is used.
  *
- * The scope passed on to [RibCoroutineWorker.onStart] as a parameter is a child scope of the [CoroutineScope] receiver,
- * but with the additional [context] elements and a [SupervisorJob].
+ * The scope passed on to [RibCoroutineWorker.onStart] as a parameter is a child scope of the
+ * [CoroutineScope] receiver, but with the additional [context] elements and a [SupervisorJob].
  *
- * Binding a worker is an asynchronous operation. To ensure [RibCoroutineWorker.onStart] is finished, callers can
- * [join][BindWorkerHandle.join] the resulting [BindWorkerHandle] when in a coroutine:
- *
+ * Binding a worker is an asynchronous operation. To ensure [RibCoroutineWorker.onStart] is
+ * finished, callers can [join][BindWorkerHandle.join] the resulting [BindWorkerHandle] when in a
+ * coroutine:
  * ```
  * val handle = coroutineScope.bind(worker)
  * handle.join() // wait for onStart to finish
@@ -97,24 +100,36 @@ public fun CoroutineScope.bind(
   worker: RibCoroutineWorker,
   context: CoroutineContext = RibDispatchers.Default,
 ): BindWorkerHandle {
-  // A job that completes once worker's onStart completes
-  var bindJob: CompletableJob? = null
-  // Start the bind coroutine undispatched to make sure we set bindJob synchronously.
-  val unbindJob = launch(context, start = CoroutineStart.UNDISPATCHED) {
-    bindJob = Job(coroutineContext.job).also {
-      // Cancel `unbindJob` if `bindJob` has cancelled. This is important to abort `onStart` if `bindJob`
-      // gets cancelled externally.
-      // Note that in case of `bindJob` failure (e.g. `onStart` throws), `unbindJob` will already fail by means of
-      // structured concurrency, but that does not happen on normal cancellation.
-      // This `bindJob` cancellation upon the `unbindJob` cancellation is also already set through structured concurrency.
-      it.invokeOnCompletion { throwable -> if (throwable is CancellationException) cancel(throwable) }
-    }
-    // Verify cancellation and dispatch (if needed) using dispatcher in context instead of continuing on current thread.
-    dispatchIfNeeded()
-    bindAndAwaitCancellation(worker, bindJob!!)
+  val bindJob: CompletableJob // A job that completes once worker's onStart completes
+  val unbindJob =
+    launch(context, { bindJob = createBindingJob() }) { bindAndAwaitCancellation(worker, bindJob) }
+  return BindWorkerHandleImpl(bindJob, unbindJob)
+}
+
+/**
+ * Guarantees to run synchronous [init] block exactly once in an undispatched manner.
+ *
+ * **Exceptions thrown in [init] block will be rethrown at call site.**
+ */
+@OptIn(ExperimentalContracts::class)
+private fun CoroutineScope.launch(
+  context: CoroutineContext = EmptyCoroutineContext,
+  init: CoroutineScope.() -> Unit = {},
+  block: suspend CoroutineScope.() -> Unit,
+): Job {
+  contract {
+    callsInPlace(init, InvocationKind.EXACTLY_ONCE)
+    callsInPlace(block, InvocationKind.AT_MOST_ONCE)
   }
-  // We know deferred is non-null because binding coroutine was started undispatched.
-  return BindWorkerHandleImpl(bindJob!!, unbindJob)
+  var initError: Throwable? = null
+  val job =
+    launch(context, CoroutineStart.UNDISPATCHED) {
+      runCatching(init).onFailure { initError = it }.getOrThrow()
+      dispatchIfNeeded()
+      block()
+    }
+  initError?.let { throw it }
+  return job
 }
 
 private suspend inline fun dispatchIfNeeded() {
@@ -127,15 +142,27 @@ private suspend inline fun dispatchIfNeeded() {
     cont.intercepted().resume(Unit)
     COROUTINE_SUSPENDED
   }
-  coroutineContext.ensureActive() // Don't continue if coroutine was cancelled after returning from dispatch.
+  // Don't continue if coroutine was cancelled after returning from dispatch.
+  coroutineContext.ensureActive()
 }
+
+private fun CoroutineScope.createBindingJob(): CompletableJob =
+  Job(coroutineContext.job).also {
+    // Cancel `unbindJob` if `bindJob` has cancelled. This is important to abort `onStart` if
+    // `bindJob` gets cancelled externally.
+    // Note that in case of `bindJob` failure (e.g. `onStart` throws), `unbindJob` will
+    // already fail by means of structured concurrency, but that does not happen on normal
+    // cancellation. This `bindJob` cancellation upon the `unbindJob` cancellation is also
+    // already set through structured concurrency.
+    it.invokeOnCompletion { throwable -> if (throwable is CancellationException) cancel(throwable) }
+  }
 
 @Suppress("TooGenericExceptionCaught") // Exception is not swallowed
 private suspend fun bindAndAwaitCancellation(worker: RibCoroutineWorker, bindJob: CompletableJob) {
   try {
     supervisorScope {
       worker.onStart(this)
-      ensureActive() // Before completing the binding deferred, make sure the binding coroutine is active.
+      ensureActive()
       bindJob.complete()
       awaitCancellation() // Never returns normally, so we are sure an exception will be caught.
     }
@@ -145,7 +172,10 @@ private suspend fun bindAndAwaitCancellation(worker: RibCoroutineWorker, bindJob
   }
 }
 
-/** Cancel the deferred if [throwable] is a [CancellationException], otherwise completes it exceptionally. */
+/**
+ * Cancel the deferred if [throwable] is a [CancellationException], otherwise completes it
+ * exceptionally.
+ */
 private fun CompletableJob.cancelOrCompleteExceptionally(throwable: Throwable) {
   when (throwable) {
     is CancellationException -> cancel(throwable)
@@ -156,7 +186,8 @@ private fun CompletableJob.cancelOrCompleteExceptionally(throwable: Throwable) {
 // ---- RibCoroutineWorker <-> Worker adapters ---- //
 
 /** Converts a [Worker] to a [RibCoroutineWorker]. */
-public fun Worker.asRibCoroutineWorker(): RibCoroutineWorker = WorkerToRibCoroutineWorkerAdapter(this)
+public fun Worker.asRibCoroutineWorker(): RibCoroutineWorker =
+  WorkerToRibCoroutineWorkerAdapter(this)
 
 /** Converts a [RibCoroutineWorker] to a [Worker]. */
 @JvmOverloads
@@ -164,11 +195,10 @@ public fun RibCoroutineWorker.asWorker(
   dispatcher: CoroutineDispatcher? = null,
 ): Worker = RibCoroutineWorkerToWorkerAdapter(this, dispatcher)
 
-internal open class WorkerToRibCoroutineWorkerAdapter(private val worker: Worker) : RibCoroutineWorker {
+internal open class WorkerToRibCoroutineWorkerAdapter(private val worker: Worker) :
+  RibCoroutineWorker {
   override suspend fun onStart(scope: CoroutineScope) {
-    withContext(worker.coroutineDispatcher) {
-      worker.onStart(scope.asWorkerScopeProvider())
-    }
+    withContext(worker.coroutineDispatcher) { worker.onStart(scope.asWorkerScopeProvider()) }
   }
 
   override fun onStop(cause: Throwable): Unit = worker.onStop()
@@ -178,19 +208,22 @@ internal open class RibCoroutineWorkerToWorkerAdapter(
   private val ribCoroutineWorker: RibCoroutineWorker,
   private val dispatcher: CoroutineDispatcher?,
 ) : Worker {
-  override val coroutineDispatcher: CoroutineDispatcher get() = dispatcher ?: super.coroutineDispatcher
+  override val coroutineDispatcher: CoroutineDispatcher
+    get() = dispatcher ?: super.coroutineDispatcher
 
   override fun onStart(lifecycle: WorkerScopeProvider) {
-    // We can start it undispatched because Worker binder will already call `onStart` in correct context,
-    // but we still want to pass in `coroutineDispatcher` to resume from suspensions in `onStart` in correct context.
+    // We can start it undispatched because Worker binder will already call `onStart` in correct
+    // context,
+    // but we still want to pass in `coroutineDispatcher` to resume from suspensions in `onStart` in
+    // correct context.
     lifecycle.coroutineScope.launch(coroutineDispatcher, start = CoroutineStart.UNDISPATCHED) {
-      supervisorScope {
-        ribCoroutineWorker.onStart(this)
-      }
+      supervisorScope { ribCoroutineWorker.onStart(this) }
     }
   }
 
-  override fun onStop(): Unit = ribCoroutineWorker.onStop(CancellationException("Worker is unbinding."))
+  override fun onStop() {
+    ribCoroutineWorker.onStop(CancellationException("Worker is unbinding."))
+  }
 }
 
 private fun CoroutineScope.asWorkerScopeProvider() = WorkerScopeProvider(asScopeProvider())

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
@@ -16,6 +16,8 @@
 package com.uber.rib.core
 
 import com.google.common.truth.Truth.assertThat
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -44,15 +46,12 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Rule
 import org.junit.Test
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 private const val ON_START_DELAY_DURATION_MILLIS = 100L
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RibCoroutineWorkerTest {
-  @get:Rule
-  val coroutineRule = RibCoroutinesRule()
+  @get:Rule val coroutineRule = RibCoroutinesRule()
   private val worker = TestRibCoroutineWorker()
 
   @Test
@@ -130,9 +129,7 @@ class RibCoroutineWorkerTest {
 
   @Test
   fun onBindingJobCancelledBeforeBinding_parentScopeCanCompleteNormally() = runTest {
-    launch {
-      bind(worker).cancel("Cancelling bind work")
-    }
+    launch { bind(worker).cancel("Cancelling bind work") }
     // if test fails to finish, there are unfinished jobs.
   }
 
@@ -186,7 +183,7 @@ class RibCoroutineWorkerTest {
 @OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
 private class ImmediateDispatcher(
   scheduler: TestCoroutineScheduler,
-  private val delegate: TestDispatcher = StandardTestDispatcher(scheduler)
+  private val delegate: TestDispatcher = StandardTestDispatcher(scheduler),
 ) : CoroutineDispatcher(), Delay by delegate {
   private var threadId: Long? = null
   var dispatchCount = 0

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -44,13 +44,14 @@ import org.mockito.kotlin.verify
 class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   @get:Rule val ribCoroutinesRule = RibCoroutinesRule()
 
-  private val worker = mock<Worker>().run {
-    if (adaptFromRibCoroutineWorker) {
-      spy(this.asRibCoroutineWorker().asWorker())
-    } else {
-      this
+  private val worker =
+    mock<Worker>().run {
+      if (adaptFromRibCoroutineWorker) {
+        spy(this.asRibCoroutineWorker().asWorker())
+      } else {
+        this
+      }
     }
-  }
   private val workerBinderListener: WorkerBinderListener = mock()
 
   private val fakeWorker = FakeWorker()


### PR DESCRIPTION
Coroutines started with `CoroutineStart.UNDISPATCHED` is guaranteed to run its block at least until the first check for cancellation / failure point, even when `CoroutineScope` is already cancelled, so we can use Kotlin contracts to have a non-nullable `bindJob`, and a `val` instead of `var`.

Incidentally, applies new spotless since when `RibCoroutineWork` was merged, spotless checks were already done when a new ktlint version/config was merged.