### PR TITLE
Bump Kotlin, Gradle, and other dependencies versions.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,11 +124,6 @@ subprojects {
             // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
             project.android {
                 if (isAndroidLibrary) {
-                    libraryVariants.all {
-                        it.generateBuildConfigProvider.configure {
-                            it.enabled = false
-                        }
-                    }
                     variantFilter { variant ->
                         if (variant.buildType.name == 'debug') {
                             variant.setIgnore(true)
@@ -154,7 +149,7 @@ subprojects {
             def extraCompilerArgs = [
                     // See https://github.com/bazelbuild/bazel/issues/15144
                     "-Xjvm-default=enable",
-                    "-Xopt-in=kotlin.RequiresOptIn"
+                    "-opt-in=kotlin.RequiresOptIn",
             ]
             if (project.name in moduleFriends.keySet()) {
                 def friendName = moduleFriends[project.name]
@@ -175,20 +170,20 @@ subprojects {
                 tasks.withType(KotlinCompile).configureEach {
                     kotlinOptions {
                         freeCompilerArgs = extraCompilerArgs
-                        jvmTarget = "1.8"
+                        jvmTarget = "11"
                     }
                 }
             } else if(!isIntelliJPlugin) {
                 project.compileKotlin {
                     kotlinOptions {
                         freeCompilerArgs = extraCompilerArgs
-                        jvmTarget = "1.8"
+                        jvmTarget = "11"
                     }
                 }
                 project.compileTestKotlin {
                     kotlinOptions {
                         freeCompilerArgs = extraCompilerArgs
-                        jvmTarget = "1.8"
+                        jvmTarget = "11"
                     }
                 }
             }

--- a/android/demos/compose/build.gradle
+++ b/android/demos/compose/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "org.jetbrains.kotlin.kapt"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.compose"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.rib.compose"
         versionCode 1
         versionName "1.0"
@@ -52,7 +52,6 @@ dependencies {
     implementation deps.kotlin.coroutines
     implementation deps.kotlin.coroutinesAndroid
     implementation deps.kotlin.coroutinesRx2
-    implementation deps.kotlin.stdlib
     implementation deps.uber.autodisposeCoroutines
     implementation deps.uber.motif
 

--- a/android/demos/compose/src/main/AndroidManifest.xml
+++ b/android/demos/compose/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.uber.rib.compose">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -14,7 +13,8 @@
         <activity
             android:name=".root.RootActivity"
             android:label="RIB Compose"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootScope.kt
@@ -16,7 +16,7 @@
 package com.uber.rib.compose.root
 
 import android.view.ViewGroup
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.compose.root.main.MainScope
 import com.uber.rib.compose.util.AnalyticsClient
@@ -45,7 +45,7 @@ interface RootScope {
 
     fun view(parentViewGroup: ViewGroup, activity: RibActivity): RootView {
       return RootView(parentViewGroup.context).apply {
-        ViewTreeLifecycleOwner.set(this, activity)
+        setViewTreeLifecycleOwner(activity)
         setViewTreeSavedStateRegistryOwner(activity)
       }
     }

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
@@ -19,7 +19,7 @@ import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.platform.ComposeView
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.compose.root.main.loggedin.LoggedInScope
 import com.uber.rib.compose.root.main.loggedout.LoggedOutScope
@@ -61,7 +61,7 @@ interface MainScope {
       presenter: ComposePresenter,
     ): ComposeView {
       return ComposeView(parentViewGroup.context).apply {
-        ViewTreeLifecycleOwner.set(this, activity)
+        setViewTreeLifecycleOwner(activity)
         setViewTreeSavedStateRegistryOwner(activity)
       }
     }

--- a/android/demos/flipper/build.gradle
+++ b/android/demos/flipper/build.gradle
@@ -23,12 +23,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.flipper"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.rib.flipper"
         versionCode 1
         versionName "1.0"

--- a/android/demos/flipper/src/main/AndroidManifest.xml
+++ b/android/demos/flipper/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.flipper"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/demos/intellij/build.gradle
+++ b/android/demos/intellij/build.gradle
@@ -23,12 +23,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.intellij"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.rib.intellij"
         versionCode 1
         versionName "1.0"

--- a/android/demos/intellij/src/main/AndroidManifest.xml
+++ b/android/demos/intellij/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.intellij"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/demos/memory-leaks/build.gradle
+++ b/android/demos/memory-leaks/build.gradle
@@ -33,12 +33,12 @@ apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'net.ltgt.nullaway'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.memory_leak"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial3"
         versionCode 1
         versionName "1.0"

--- a/android/demos/memory-leaks/src/main/AndroidManifest.xml
+++ b/android/demos/memory-leaks/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.memory_leak"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -16,12 +16,14 @@
 
 def versions = [
     androidx: [
+        activity: '1.7.0',
         annotations: '1.1.0',
         appcompat: '1.3.0',
         compose: [
-          compiler: "1.3.0",
-          libraries: "1.2.1"
+          compiler: "1.4.6",
+          libraries: "1.4.0"
         ],
+        lifecycle: '2.5.1',
         percent: '1.0.0',
         savedState: "1.2.0"
     ],
@@ -31,7 +33,7 @@ def versions = [
     errorProne: '2.3.3',
     gjf: '1.16.0',
     intellij: "2022.2.4",
-    kotlin: "1.7.10",
+    kotlin: "1.8.20",
     ktfmt: '0.43',
     ktlint: '0.48.2',
     motif: '0.3.4',
@@ -59,20 +61,20 @@ def build = [
     ci: 'true' == System.getenv('CI'),
     minSdkVersion: 21,
     targetSdkVersion: 28,
-    javaVersion: JavaVersion.VERSION_1_8,
+    javaVersion: JavaVersion.VERSION_11,
     guavaJre: "com.google.guava:guava:27.1-jre",
     commonsLang: "commons-lang:commons-lang:2.6",
-    intellijPlugin: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.11.0",
+    intellijPlugin: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.13.1",
     errorProne: "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneJavac: "com.google.errorprone:javac:9+181-r4173-1",
     errorProneCore: "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneTestHelpers: "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
     nullAway: 'com.uber.nullaway:nullaway:0.9.0',
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:7.2.2',
+        android: 'com.android.tools.build:gradle:7.4.2',
         apt: "net.ltgt.gradle:gradle-apt-plugin:0.21",
         errorprone: "net.ltgt.gradle:gradle-errorprone-plugin:1.3.0",
-        gradleMavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.18.0",
+        gradleMavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.25.2",
         japicmp: 'me.champeau.gradle:japicmp-gradle-plugin:0.2.8',
         kapt: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
@@ -82,9 +84,9 @@ def build = [
 ]
 
 def androidx = [
-    activity: "androidx.activity:activity:1.3.0-alpha08",
-    activityCompose: "androidx.activity:activity-compose:1.3.0-beta02",
-    activityKtx: "androidx.activity:activity-ktx:1.3.0-beta02",
+    activity: "androidx.activity:activity:${versions.androidx.activity}",
+    activityCompose: "androidx.activity:activity-compose:${versions.androidx.activity}",
+    activityKtx: "androidx.activity:activity-ktx:${versions.androidx.activity}",
     annotations: "androidx.annotation:annotation:${versions.androidx.annotations}",
     appcompat: "androidx.appcompat:appcompat:${versions.androidx.appcompat}",
     composeAnimation: "androidx.compose.animation:animation:${versions.androidx.compose.libraries}",
@@ -95,7 +97,7 @@ def androidx = [
     composeRuntimeRxJava2: "androidx.compose.runtime:runtime-rxjava2:${versions.androidx.compose.libraries}",
     composeUi: "androidx.compose.ui:ui:${versions.androidx.compose.libraries}",
     composeUiTooling: "androidx.compose.ui:ui-tooling:${versions.androidx.compose.libraries}",
-    composeViewModel: "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha05",
+    composeViewModel: "androidx.lifecycle:lifecycle-viewmodel-compose:${versions.androidx.lifecycle}",
     percent: "androidx.percentlayout:percentlayout:${versions.androidx.percent}",
     savedState: "androidx.savedstate:savedstate:${versions.androidx.savedState}"
 ]

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/android/libraries/rib-android-compose/build.gradle
+++ b/android/libraries/rib-android-compose/build.gradle
@@ -19,15 +19,15 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.android.compose"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
     buildFeatures {
         compose true
+        buildConfig false
     }
     composeOptions {
         kotlinCompilerExtensionVersion deps.versions.androidx.compose.compiler

--- a/android/libraries/rib-android-compose/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-android-compose/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.android.compose"/>

--- a/android/libraries/rib-android-core/build.gradle
+++ b/android/libraries/rib-android-core/build.gradle
@@ -19,17 +19,20 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.android.core"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 
     testOptions {
@@ -43,7 +46,6 @@ dependencies {
     implementation deps.apt.javaxInject
     implementation deps.androidx.annotations
     implementation deps.androidx.appcompat
-    implementation deps.kotlin.stdlib
     testImplementation deps.androidx.appcompat
     testImplementation deps.external.roboelectricBase
 }

--- a/android/libraries/rib-android-core/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-android-core/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.android.core"/>

--- a/android/libraries/rib-android/build.gradle
+++ b/android/libraries/rib-android/build.gradle
@@ -19,12 +19,11 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'com.vanniktech.maven.publish'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.android"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {

--- a/android/libraries/rib-android/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-android/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.android"/>

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation deps.external.reactiveStreams
     implementation deps.external.rxrelay2
     implementation deps.external.rxjava2
-    implementation deps.kotlin.stdlib
     implementation deps.uber.autodispose
     api deps.uber.autodisposeLifecycle
     implementation deps.apt.javaxInject
@@ -56,7 +55,6 @@ dependencies {
     testImplementation project(":libraries:rib-coroutines-test")
     testImplementation deps.androidx.annotations
     testImplementation deps.apt.androidApi
-    testImplementation deps.kotlin.stdlib
     testImplementation deps.test.junit
     testImplementation deps.test.mockito
     testImplementation deps.test.mockitoKotlin

--- a/android/libraries/rib-compiler-app/build.gradle
+++ b/android/libraries/rib-compiler-app/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation deps.apt.autoCommon
     implementation deps.apt.javapoet
     implementation deps.external.dagger
-    implementation deps.kotlin.stdlib
 
     compileOnly deps.androidx.annotations
     compileOnly deps.apt.autoService

--- a/android/libraries/rib-compiler-test/build.gradle
+++ b/android/libraries/rib-compiler-test/build.gradle
@@ -23,7 +23,6 @@ apply plugin: "com.vanniktech.maven.publish"
 dependencies {
     implementation project(":libraries:rib-compiler-app")
     implementation deps.apt.javapoet
-    implementation deps.kotlin.stdlib
 
     compileOnly deps.androidx.annotations
     compileOnly deps.apt.autoService

--- a/android/libraries/rib-coroutines-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineScopes.kt
+++ b/android/libraries/rib-coroutines-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineScopes.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.uber.rib.core
 
 import android.app.Application

--- a/android/libraries/rib-coroutines/build.gradle
+++ b/android/libraries/rib-coroutines/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     api deps.uber.autodisposeCoroutines
     api deps.kotlin.coroutinesAndroid
     api deps.kotlin.coroutinesRx2
-    implementation deps.kotlin.stdlib
 
     compileOnly deps.external.android
 

--- a/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
+++ b/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.uber.rib.core
 
 /** Debugging utilities when working with Routers. */

--- a/android/libraries/rib-screen-stack-base/build.gradle
+++ b/android/libraries/rib-screen-stack-base/build.gradle
@@ -19,17 +19,20 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.ubercab.core.screenstack.base"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 }
 

--- a/android/libraries/rib-screen-stack-base/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-screen-stack-base/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.ubercab.core.screenstack.base">
-    <application />
-</manifest>

--- a/android/libraries/rib-test/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-test/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.assert"/>

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.uber.rib.core
 
 @SuppressWarnings("RibInteractorOnIteractor")

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.uber.rib.core
 
 import org.mockito.AdditionalMatchers.or

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/WorkerHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/WorkerHelper.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.uber.rib.core
 
 import com.uber.rib.core.lifecycle.WorkerEvent

--- a/android/libraries/rib-workflow-test/build.gradle
+++ b/android/libraries/rib-workflow-test/build.gradle
@@ -19,17 +19,20 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.workflow.test"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 
     // This module is only testing utilities. Given this code isn't intended to be run inside a production
@@ -45,7 +48,6 @@ dependencies {
     api deps.external.guavaAndroid
     api deps.external.rxjava2
     implementation deps.androidx.annotations
-    implementation deps.kotlin.stdlib
     implementation deps.test.truth
 }
 

--- a/android/libraries/rib-workflow-test/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-workflow-test/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.workflow.test"/>

--- a/android/libraries/rib-workflow/build.gradle
+++ b/android/libraries/rib-workflow/build.gradle
@@ -19,17 +19,20 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.workflow"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 }
 
@@ -37,7 +40,6 @@ dependencies {
     implementation deps.androidx.annotations
     implementation deps.external.rxandroid2
     implementation deps.external.rxkotlin
-    implementation deps.kotlin.stdlib
     api deps.external.guavaAndroid
     api deps.external.rxjava2
     api project(":libraries:rib-android")

--- a/android/libraries/rib-workflow/src/main/AndroidManifest.xml
+++ b/android/libraries/rib-workflow/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.workflow"/>

--- a/android/tooling/rib-flipper-plugin/build.gradle
+++ b/android/tooling/rib-flipper-plugin/build.gradle
@@ -19,17 +19,20 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.flipper"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 
     testOptions {

--- a/android/tooling/rib-flipper-plugin/src/main/AndroidManifest.xml
+++ b/android/tooling/rib-flipper-plugin/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.uber.rib.flipper"/>

--- a/android/tooling/rib-intellij-plugin/native/intellij-broadcast-rib/build.gradle
+++ b/android/tooling/rib-intellij-plugin/native/intellij-broadcast-rib/build.gradle
@@ -19,8 +19,8 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.debug.broadcast.rib"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
         minSdkVersion deps.build.minSdkVersion
@@ -30,6 +30,10 @@ android {
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 
     testOptions {

--- a/android/tooling/rib-intellij-plugin/native/intellij-broadcast-rib/src/main/AndroidManifest.xml
+++ b/android/tooling/rib-intellij-plugin/native/intellij-broadcast-rib/src/main/AndroidManifest.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest
-    package="com.uber.debug.broadcast.rib"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <application />
-</manifest>

--- a/android/tooling/utils/intellij-broadcast-core/build.gradle
+++ b/android/tooling/utils/intellij-broadcast-core/build.gradle
@@ -18,17 +18,20 @@ apply plugin: 'com.android.library'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.debug.broadcast.core"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
     }
 
     compileOptions {
         sourceCompatibility deps.build.javaVersion
         targetCompatibility deps.build.javaVersion
+    }
+
+    buildFeatures {
+        buildConfig false
     }
 
     testOptions {

--- a/android/tooling/utils/intellij-broadcast-core/src/main/AndroidManifest.xml
+++ b/android/tooling/utils/intellij-broadcast-core/src/main/AndroidManifest.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest
-    package="com.uber.debug.broadcast.core"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <application />
-</manifest>

--- a/android/tutorials/tutorial1/build.gradle
+++ b/android/tutorials/tutorial1/build.gradle
@@ -27,12 +27,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'net.ltgt.nullaway'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.tutorial1"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial1"
         versionCode 1
         versionName "1.0"

--- a/android/tutorials/tutorial1/src/main/AndroidManifest.xml
+++ b/android/tutorials/tutorial1/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.tutorial1"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/tutorials/tutorial2/build.gradle
+++ b/android/tutorials/tutorial2/build.gradle
@@ -27,12 +27,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'net.ltgt.nullaway'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.tutorial1"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial2"
         versionCode 1
         versionName "1.0"

--- a/android/tutorials/tutorial2/src/main/AndroidManifest.xml
+++ b/android/tutorials/tutorial2/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.tutorial1"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/tutorials/tutorial3-completed/build.gradle
+++ b/android/tutorials/tutorial3-completed/build.gradle
@@ -23,12 +23,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.tutorial1"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial3"
         versionCode 1
         versionName "1.0"

--- a/android/tutorials/tutorial3-completed/src/main/AndroidManifest.xml
+++ b/android/tutorials/tutorial3-completed/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.tutorial1"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/tutorials/tutorial3/build.gradle
+++ b/android/tutorials/tutorial3/build.gradle
@@ -23,12 +23,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.tutorial1"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial3"
         versionCode 1
         versionName "1.0"

--- a/android/tutorials/tutorial3/src/main/AndroidManifest.xml
+++ b/android/tutorials/tutorial3/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.tutorial1"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/tutorials/tutorial4/build.gradle
+++ b/android/tutorials/tutorial4/build.gradle
@@ -23,12 +23,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion deps.build.compileSdkVersion
-    buildToolsVersion deps.build.buildToolsVersion
+    namespace "com.uber.rib.tutorial4"
+    compileSdk deps.build.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
-        targetSdkVersion deps.build.targetSdkVersion
+        minSdk deps.build.minSdkVersion
+        targetSdk deps.build.targetSdkVersion
         applicationId "com.uber.tutorial3"
         versionCode 1
         versionName "1.0"

--- a/android/tutorials/tutorial4/src/main/AndroidManifest.xml
+++ b/android/tutorials/tutorial4/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest package="com.uber.rib.tutorial4"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:required="true" android:glEsVersion='0x00020000'/>
@@ -18,7 +17,8 @@
         android:theme="@style/Theme.AppCompat.Light"
         tools:replace="android:theme">
         <activity
-            android:name="com.uber.rib.RootActivity">
+            android:name="com.uber.rib.RootActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
Fixes #566 

Kotlin 1.7.10 -> 1.8.20
Gradle 7.3.3 -> 8.1.1
AndroidX Lifecycle ViewModel Compose 1.0.0-alpha05 -> 2.5.1
AndroidX Activity 1.3.0-alpha08 -> 1.7.0
AndroidX Activity KTX 1.3.0-beta02 -> 1.7.0
AndroidX Activity Compose 1.3.0-beta02 -> 1.7.0
Compose compiler 1.3.0 -> 1.4.6
Compose libraries 1.2.1 -> 1.4.0
Java version 1.8 -> 11
IntelliJ plugin 1.11.0 -> 1.13.1 (1.13.2 onwards fails test `ribGenerators_shouldGenerateClassesThatCompiler` for reasons beyond my understanding, cc @idanakav for vis)
AGP 7.2.2 -> 7.4.2 (8.0 not supported in IJ 2023.1 bundled Android plugin)
gradle-maven-publish 0.18.0 -> 0.25.2

### Additional changes

- Move package string from manifests to `android.namespace` in Gradle build scripts.
- Remove `targetSdk` from Android libraries (only applications should provide it)
- Remove `buildToolsVersion`.
- `compileSdkVersion`, `minSdkVersion`, `targetSdkVersion` swapped to `compileSdk`, `minSdk`, `targetSdk`.
- Disablement of `buildConfig` is now done by `buildFeatures.buildConfig = false` instead of in the project `build.gradle`.
- Added `exported="true"` in demo Android projects activities.
- `-Xfriend-paths` `kotlinc` option seemingly only works now if we use `@file:Suppress("invisible_reference", "invisible_member")` in files that access internal components.
- `androidx.lifecycle.ViewTreeLifecycleOwner(View, LifecycleOwner)` has been replaced with `View.setViewTreeLifecycleOwner(LifecycleOwner)`.
- Removed unnecessary dependencies on Kotlin stdlib, as the Kotlin JVM plugin automatically adds it. For reasons beyond my understanding, removing it from `android/libraries/rib-test` fails gradle sync with the following error, so it's the only place it's still kept.
```
com.intellij.openapi.externalSystem.model.ExternalSystemException: Could not resolve all dependencies for configuration ':libraries:rib-coroutines:testCompileClasspath'.
Cannot change dependencies of dependency configuration ':libraries:rib-test:api' after it has been included in dependency resolution.
```

### Tests

Did a quick smoke test with a `-LOCAL` build against our monorepo.