### PR TITLE
Open `lifecycleFlow`, thus enabling it for mocking

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityEvent.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityEvent.kt
@@ -15,8 +15,6 @@
  */
 package com.uber.rib.core.lifecycle
 
-import com.uber.rib.core.lifecycle.ActivityEvent.BaseType
-
 /**
  * Base class for Activity events, useful for when you want a stream of both lifecycle and callback
  * events.

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityLifecycleEvent.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/lifecycle/ActivityLifecycleEvent.kt
@@ -22,7 +22,7 @@ open class ActivityLifecycleEvent
 private constructor(
   /** @return this event's type. */
   override val type: Type,
-) : ActivityEvent {
+) : ActivityEvent, Comparable<ActivityLifecycleEvent> {
 
   /** Types of activity events that can occur. */
   enum class Type : ActivityEvent.BaseType {
@@ -34,6 +34,8 @@ private constructor(
     STOP,
     DESTROY,
   }
+
+  override fun compareTo(other: ActivityLifecycleEvent): Int = type.compareTo(other.type)
 
   /** An [ActivityLifecycleEvent] that encapsulates information from [Activity.onCreate]. */
   open class Create(

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -42,11 +42,10 @@ dependencies {
     implementation deps.apt.javaxInject
 
     implementation deps.uber.autodisposeCoroutines
-    implementation deps.kotlin.coroutines
     implementation deps.kotlin.coroutinesRx2
     api deps.kotlin.stdlib
-
-    implementation project(":libraries:rib-coroutines")
+    api deps.kotlin.coroutines
+    api project(":libraries:rib-coroutines")
 
     compileOnly deps.apt.daggerCompiler
     compileOnly deps.androidx.annotations

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation deps.uber.autodisposeCoroutines
     implementation deps.kotlin.coroutines
     implementation deps.kotlin.coroutinesRx2
+    api deps.kotlin.stdlib
 
     implementation project(":libraries:rib-coroutines")
 

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -43,6 +43,10 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType {
   public open val lifecycleFlow: SharedFlow<InteractorEvent>
     get() = _lifecycleFlow
 
+  @Volatile private var _lifecycleObservable: Observable<InteractorEvent>? = null
+  private val lifecycleObservable
+    get() = ::_lifecycleObservable.setIfNullAndGet { lifecycleFlow.asObservable() }
+
   private val routerDelegate = InitOnceProperty<R>()
 
   /** @return the router for this interactor. */
@@ -55,7 +59,7 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType {
 
   // ---- LifecycleScopeProvider overrides ---- //
 
-  final override fun lifecycle(): Observable<InteractorEvent> = lifecycleFlow.asObservable()
+  final override fun lifecycle(): Observable<InteractorEvent> = lifecycleObservable
 
   final override fun correspondingEvents(): CorrespondingEventsFunction<InteractorEvent> =
     LIFECYCLE_MAP_FUNCTION

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/InteractorType.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/InteractorType.kt
@@ -23,6 +23,13 @@ import com.uber.rib.core.lifecycle.InteractorEvent
  * types
  */
 public interface InteractorType : LifecycleScopeProvider<InteractorEvent> {
+  /** @return `true` if the controller is attached, `false` if not. */
   public fun isAttached(): Boolean
+
+  /**
+   * Handle an activity back press.
+   *
+   * @return whether this interactor took action in response to a back press.
+   */
   public fun handleBackPress(): Boolean
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/LazyBackingProperty.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/LazyBackingProperty.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import kotlin.reflect.KMutableProperty0
+
+/**
+ * Lazily sets a value produced by [initializer] into the receiver mutable property and returns it
+ * if the property is set to `null`, or returns the value set into the property without calling
+ * [initializer].
+ *
+ * This is similar to [lazy].
+ *
+ * This function is needed because of Mockito mocking. When we mock a class, mockito does not call
+ * any constructor and does not initialize private fields of the class. By having a null (unset)
+ * field being dynamically set by a final function, we can overcome this issue.
+ *
+ * To properly support concurrency, the backing mutable property should be [Volatile].
+ */
+internal inline fun <T : Any> KMutableProperty0<T?>.setIfNullAndGet(
+  initializer: () -> T,
+): T = get() ?: synchronized(Lock) { get() ?: initializer().also { set(it) } }
+
+private object Lock

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -35,13 +35,8 @@ import org.checkerframework.checker.guieffect.qual.UIEffect
  */
 public abstract class Presenter : ScopeProvider {
   private val _lifecycleFlow = MutableSharedFlow<PresenterEvent>(1, 0, BufferOverflow.DROP_OLDEST)
-
-  // We expose lifecycleFlow internally to avoid some unnecessary Rx-Coroutine interop. Use it
-  // instead of `lifecycle()`.
-  @get:JvmSynthetic
-  internal val lifecycleFlow: SharedFlow<PresenterEvent>
+  public open val lifecycleFlow: SharedFlow<PresenterEvent>
     get() = _lifecycleFlow
-  private val lifecycleObservable = lifecycleFlow.asObservable()
 
   /** @return `true` if the presenter is loaded, `false` if not. */
   protected var isLoaded: Boolean = false
@@ -69,9 +64,10 @@ public abstract class Presenter : ScopeProvider {
   @UIEffect @CallSuper protected open fun willUnload() {}
 
   /** @return an observable of this controller's lifecycle events. */
-  public open fun lifecycle(): Observable<PresenterEvent> = lifecycleObservable
+  public fun lifecycle(): Observable<PresenterEvent> = lifecycleFlow.asObservable()
 
-  override fun requestScope(): CompletableSource = _lifecycleFlow.asScopeCompletable(lifecycleRange)
+  final override fun requestScope(): CompletableSource =
+    lifecycleFlow.asScopeCompletable(lifecycleRange)
 
   internal companion object {
     @get:JvmSynthetic internal val lifecycleRange = PresenterEvent.LOADED..PresenterEvent.UNLOADED

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -38,6 +38,10 @@ public abstract class Presenter : ScopeProvider {
   public open val lifecycleFlow: SharedFlow<PresenterEvent>
     get() = _lifecycleFlow
 
+  @Volatile private var _lifecycleObservable: Observable<PresenterEvent>? = null
+  private val lifecycleObservable
+    get() = ::_lifecycleObservable.setIfNullAndGet { lifecycleFlow.asObservable() }
+
   /** @return `true` if the presenter is loaded, `false` if not. */
   protected var isLoaded: Boolean = false
     private set
@@ -64,7 +68,7 @@ public abstract class Presenter : ScopeProvider {
   @UIEffect @CallSuper protected open fun willUnload() {}
 
   /** @return an observable of this controller's lifecycle events. */
-  public fun lifecycle(): Observable<PresenterEvent> = lifecycleFlow.asObservable()
+  public fun lifecycle(): Observable<PresenterEvent> = lifecycleObservable
 
   final override fun requestScope(): CompletableSource =
     lifecycleFlow.asScopeCompletable(lifecycleRange)

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
@@ -198,7 +198,9 @@ public fun RibCoroutineWorker.asWorker(
 internal open class WorkerToRibCoroutineWorkerAdapter(private val worker: Worker) :
   RibCoroutineWorker {
   override suspend fun onStart(scope: CoroutineScope) {
-    withContext(worker.coroutineContext) { worker.onStart(scope.asWorkerScopeProvider()) }
+    withContext(worker.coroutineContext ?: EmptyCoroutineContext) {
+      worker.onStart(scope.asWorkerScopeProvider())
+    }
   }
 
   override fun onStop(cause: Throwable): Unit = worker.onStop()

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/LazyBackingPropertyTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/LazyBackingPropertyTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import com.google.common.truth.Truth.assertThat
+import io.reactivex.Observable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.channels.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LazyBackingPropertyTest {
+  @Volatile private var _expensiveObject: ExpensiveObject? = null
+  private val expensiveObject
+    get() = ::_expensiveObject.setIfNullAndGet { ExpensiveObject() }
+
+  @Test
+  fun `Stress test fetching a LazyBackingProperty from multiple concurrent coroutines`() = runTest {
+    val set =
+      produce(RibDispatchers.IO) { repeat(10_000) { launch { send(expensiveObject) } } }
+        .toList()
+        .toSet()
+    assertThat(set).hasSize(1)
+  }
+
+  @Test
+  fun `Value is preserved on mocked class`() {
+    val instance = mock<ClassToBeMocked>()
+    instance.prop.test().assertValues(1, 2, 3)
+  }
+}
+
+private open class ClassToBeMocked {
+  @Volatile private var _prop: Observable<Int>? = null
+  val prop: Observable<Int>
+    get() = ::_prop.setIfNullAndGet { Observable.just(1, 2, 3) }
+}
+
+private class ExpensiveObject {
+  init {
+    Thread.sleep(100) // Simulate expensive object to make concurrent access more frequent
+  }
+}

--- a/android/libraries/rib-test/build.gradle
+++ b/android/libraries/rib-test/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = deps.build.javaVersion.toString()
 targetCompatibility = deps.build.javaVersion.toString()
 
 dependencies {
-    implementation project(":libraries:rib-base")
+    api project(":libraries:rib-base")
     implementation deps.external.rxjava2
     implementation deps.kotlin.stdlib
     api deps.test.junit


### PR DESCRIPTION
Also, finalizes all `LifecycleScopeProvider` methods in order to impede mocking or overriding. Those methods will have `lifecycleFlow` as the source of truth (either real or mocked).