### PR TITLE
[WorkerBinder] Guard against potential Worker.coroutineContext being null while using Mockito

### DIFF
--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/InteractorAndRouterTest.kt
@@ -193,9 +193,11 @@ class InteractorAndRouterTest {
 
   private class TestInteractor(private val mChildInteractor: Interactor<*, *>) :
     Interactor<TestPresenter, Router<TestInteractor>>() {
+    val mockedWorker: Worker = mock()
     override fun didBecomeActive(savedInstanceState: Bundle?) {
       super.didBecomeActive(savedInstanceState)
       val router: Router<*> = FakeRouter(mChildInteractor, getInstance(), Thread.currentThread())
+      WorkerBinder.bind(this, mockedWorker)
       this.router.attachChild(router)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

Tests that internally bind workers on Interactor's/Presenter and provide its Worker dependency via a mock (in Mockito) will start failing due to Mockito changing the default return type of `Worker.coroutineContext` from `EmptyCoroutineContext` to a non-possible null type otherwise.

This PR just guards against this possibility for testing and extract a function to easily get this context at binding logic in a safer manner

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

https://github.com/uber/RIBs/issues/574

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->

Expanded test on InteractorAndRouterTest. Will add few more test cases on new Workers demo module as well