### PR TITLE
Migrate from deprecated `@JvmDefault` to compiler option `-Xjvm-default=all`

### DIFF
--- a/android/conventions/src/main/kotlin/ribs.kotlin-android-application-conventions.gradle.kts
+++ b/android/conventions/src/main/kotlin/ribs.kotlin-android-application-conventions.gradle.kts
@@ -72,7 +72,7 @@ androidComponents {
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         freeCompilerArgs.addAll(
-            "-Xjvm-default=enable",
+            "-Xjvm-default=all",
             "-opt-in=kotlin.RequiresOptIn",
         )
     }

--- a/android/conventions/src/main/kotlin/ribs.kotlin-android-library-conventions.gradle.kts
+++ b/android/conventions/src/main/kotlin/ribs.kotlin-android-library-conventions.gradle.kts
@@ -69,7 +69,7 @@ tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         freeCompilerArgs.addAll(
             "-Xexplicit-api=warning",
-            "-Xjvm-default=enable",
+            "-Xjvm-default=all",
             "-opt-in=kotlin.RequiresOptIn",
         )
     }

--- a/android/conventions/src/main/kotlin/ribs.kotlin-library-conventions.gradle.kts
+++ b/android/conventions/src/main/kotlin/ribs.kotlin-library-conventions.gradle.kts
@@ -25,6 +25,6 @@ kotlin {
 
 tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask::class.java) {
     compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=enable")
+        freeCompilerArgs.add("-Xjvm-default=all")
     }
 }

--- a/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/ActivityDelegate.kt
+++ b/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/ActivityDelegate.kt
@@ -27,25 +27,24 @@ import androidx.annotation.IntRange
  */
 interface ActivityDelegate {
   /** @see [Activity.onCreate] */
-  @JvmDefault fun onCreate(savedInstanceState: Bundle?) {}
+  fun onCreate(savedInstanceState: Bundle?) {}
 
   /** @see [Activity.onStart] */
-  @JvmDefault fun onStart() {}
+  fun onStart() {}
 
   /** @see [Activity.onResume] */
-  @JvmDefault fun onResume() {}
+  fun onResume() {}
 
   /** @see [Activity.onPause] */
-  @JvmDefault fun onPause() {}
+  fun onPause() {}
 
   /** @see [Activity.onStop] */
-  @JvmDefault fun onStop() {}
+  fun onStop() {}
 
   /** @see [Activity.onDestroy] */
-  @JvmDefault fun onDestroy() {}
+  fun onDestroy() {}
 
   /** @see [Activity.onActivityResult] */
-  @JvmDefault
   fun onActivityResult(
     activity: Activity,
     requestCode: Int,
@@ -54,7 +53,6 @@ interface ActivityDelegate {
   ) {}
 
   /** @see [Activity.onRequestPermissionsResult] */
-  @JvmDefault
   fun onRequestPermissionsResult(
     activity: Activity,
     @IntRange(from = 0, to = 255) requestCode: Int,

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RxActivityEvents.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RxActivityEvents.kt
@@ -32,7 +32,6 @@ interface RxActivityEvents {
    * @param clazz The [ActivityLifecycleEvent] subclass you want.
    * @return an observable of this activity's lifecycle events.
    */
-  @JvmDefault
   fun <T : ActivityLifecycleEvent> lifecycle(clazz: Class<T>): Observable<T> {
     return lifecycle()
       .filter { activityEvent -> clazz.isAssignableFrom(activityEvent.javaClass) }
@@ -44,7 +43,6 @@ interface RxActivityEvents {
    * @param clazz The [ActivityCallbackEvent] subclass you want.
    * @return an observable of this activity's callbacks events.
    */
-  @JvmDefault
   fun <T : ActivityCallbackEvent> callbacks(clazz: Class<T>): Observable<T> {
     return callbacks()
       .filter { activityEvent -> clazz.isAssignableFrom(activityEvent.javaClass) }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibCoroutineWorker.kt
@@ -49,7 +49,7 @@ public fun interface RibCoroutineWorker : RibActionEmitter {
   public suspend fun onStart(scope: CoroutineScope)
 
   /** Called when worker is stopped with [cause]. Should be fast, be non-blocking and not throw. */
-  @JvmDefault public fun onStop(cause: Throwable) {}
+  public fun onStop(cause: Throwable) {}
 }
 
 // ---- Binder ---- //

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
@@ -50,7 +50,6 @@ public interface Worker : RibActionEmitter {
    * 3) After calling WorkerBinder.bind(interactor, workers, RibDispatchers.IO). [uiWorker] will be
    *    guaranteed to be called on RibDispatchers.Main
    */
-  @JvmDefault
   public val coroutineContext: CoroutineContext
     get() = EmptyCoroutineContext
 
@@ -59,8 +58,8 @@ public interface Worker : RibActionEmitter {
    *
    * @param lifecycle The lifecycle of the worker to use for subscriptions.
    */
-  @JvmDefault public fun onStart(lifecycle: WorkerScopeProvider) {}
+  public fun onStart(lifecycle: WorkerScopeProvider) {}
 
   /** Called when the worker is stopped. */
-  @JvmDefault public fun onStop() {}
+  public fun onStop() {}
 }

--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/RouterNavigatorState.kt
@@ -19,7 +19,6 @@ package com.uber.rib.core
 public interface RouterNavigatorState {
 
   /** @return identifier for a [StackRouterNavigator] state. */
-  @JvmDefault
   public fun stateName(): String {
     return if (this.javaClass.isEnum) {
       (this as Enum<*>).name
@@ -39,5 +38,5 @@ public interface RouterNavigatorState {
    * [RouterNavigator.DetachCallback.onPostDetachFromHost] and will be recreated for next
    * [RouterNavigator.AttachTransition]
    */
-  @JvmDefault public fun isCacheable(): Boolean = false
+  public fun isCacheable(): Boolean = false
 }


### PR DESCRIPTION
[Docs](https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/) state that:

> If you used the @JvmDefault annotation before, you can safely remove it and use one of the new modes. If you already used -Xjvm-default=enable, which generated only the default method implementations, you can now replace it with -Xjvm-default=all.

Fixes #571 