### PR TITLE
Make use of `jvmToolchain` for building the project.

### DIFF
--- a/android/demos/compose/build.gradle
+++ b/android/demos/compose/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "org.jetbrains.kotlin.kapt"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.compose"
     compileSdk deps.build.compileSdkVersion

--- a/android/demos/flipper/build.gradle
+++ b/android/demos/flipper/build.gradle
@@ -22,6 +22,12 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.rib.flipper"
     compileSdk deps.build.compileSdkVersion

--- a/android/demos/intellij/build.gradle
+++ b/android/demos/intellij/build.gradle
@@ -22,6 +22,12 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.rib.intellij"
     compileSdk deps.build.compileSdkVersion

--- a/android/demos/memory-leaks/build.gradle
+++ b/android/demos/memory-leaks/build.gradle
@@ -29,6 +29,13 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'net.ltgt.nullaway'
 

--- a/android/demos/rib-workers/build.gradle
+++ b/android/demos/rib-workers/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "org.jetbrains.kotlin.kapt"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.workers"
     compileSdk deps.build.compileSdkVersion

--- a/android/libraries/rib-android-compose/build.gradle
+++ b/android/libraries/rib-android-compose/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.android.compose"
     compileSdk deps.build.compileSdkVersion
@@ -52,8 +57,4 @@ dependencies {
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin
     testImplementation project(":libraries:rib-test")
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-android-core/build.gradle
+++ b/android/libraries/rib-android-core/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.android.core"
     compileSdk deps.build.compileSdkVersion
@@ -48,8 +53,4 @@ dependencies {
     implementation deps.androidx.appcompat
     testImplementation deps.androidx.appcompat
     testImplementation deps.external.roboelectricBase
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-android/build.gradle
+++ b/android/libraries/rib-android/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'com.vanniktech.maven.publish'
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.android"
     compileSdk deps.build.compileSdkVersion
@@ -55,8 +60,4 @@ dependencies {
     testImplementation deps.androidx.appcompat
     testImplementation deps.test.mockitoKotlin
     testImplementation project(":libraries:rib-test")
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -24,8 +24,10 @@ apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "org.jetbrains.kotlin.kapt"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     // RIBs themselves don't need to use dagger. But the base library does use dagger
@@ -62,8 +64,4 @@ dependencies {
     testImplementation(project(":libraries:rib-test")) {
         transitive = false
     }
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-compiler-app/build.gradle
+++ b/android/libraries/rib-compiler-app/build.gradle
@@ -17,8 +17,10 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     implementation project(":libraries:rib-base")
@@ -32,10 +34,6 @@ dependencies {
     compileOnly deps.apt.androidApi
 
     testImplementation deps.test.compileTesting
-}
-
-kotlin {
-    explicitApi()
 }
 
 // https://code.google.com/p/android/issues/detail?id=64887

--- a/android/libraries/rib-compiler-test/build.gradle
+++ b/android/libraries/rib-compiler-test/build.gradle
@@ -20,6 +20,10 @@ apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "org.jetbrains.kotlin.kapt"
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 dependencies {
     implementation project(":libraries:rib-compiler-app")
     implementation deps.apt.javapoet

--- a/android/libraries/rib-coroutines-test/build.gradle
+++ b/android/libraries/rib-coroutines-test/build.gradle
@@ -18,8 +18,10 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     api project(':libraries:rib-coroutines')
@@ -39,8 +41,4 @@ dependencies {
     testImplementation deps.androidx.annotations
     testImplementation deps.apt.androidApi
 
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-coroutines/build.gradle
+++ b/android/libraries/rib-coroutines/build.gradle
@@ -18,8 +18,10 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
 
@@ -38,8 +40,4 @@ dependencies {
     testImplementation deps.kotlin.coroutinesTest
     testImplementation deps.androidx.annotations
     testImplementation deps.apt.androidApi
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-debug-utils/build.gradle
+++ b/android/libraries/rib-debug-utils/build.gradle
@@ -17,13 +17,11 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     implementation project(":libraries:rib-base")
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-router-navigator/build.gradle
+++ b/android/libraries/rib-router-navigator/build.gradle
@@ -17,8 +17,10 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     implementation deps.external.checkerQual
@@ -32,8 +34,4 @@ dependencies {
     testImplementation deps.test.junit
     testImplementation deps.test.mockitoKotlin
     testImplementation deps.test.truth
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-screen-stack-base/build.gradle
+++ b/android/libraries/rib-screen-stack-base/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.ubercab.core.screenstack.base"
     compileSdk deps.build.compileSdkVersion
@@ -44,8 +49,4 @@ dependencies {
     implementation deps.uber.autodisposeCoroutines
     implementation deps.kotlin.coroutinesAndroid
     implementation deps.kotlin.coroutinesRx2
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-test/build.gradle
+++ b/android/libraries/rib-test/build.gradle
@@ -17,8 +17,10 @@
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.vanniktech.maven.publish"
 
-sourceCompatibility = deps.build.javaVersion.toString()
-targetCompatibility = deps.build.javaVersion.toString()
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
 
 dependencies {
     api project(":libraries:rib-base")
@@ -28,8 +30,4 @@ dependencies {
     api deps.test.truth
     api deps.test.mockito
     implementation deps.test.mockitoKotlin
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-workflow-test/build.gradle
+++ b/android/libraries/rib-workflow-test/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.workflow.test"
     compileSdk deps.build.compileSdkVersion
@@ -49,8 +54,4 @@ dependencies {
     api deps.external.rxjava2
     implementation deps.androidx.annotations
     implementation deps.test.truth
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/libraries/rib-workflow/build.gradle
+++ b/android/libraries/rib-workflow/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.workflow"
     compileSdk deps.build.compileSdkVersion
@@ -46,8 +51,4 @@ dependencies {
     testImplementation deps.test.junit
     testImplementation deps.test.truth
     testImplementation deps.test.mockito
-}
-
-kotlin {
-    explicitApi()
 }

--- a/android/tooling/rib-flipper-plugin/build.gradle
+++ b/android/tooling/rib-flipper-plugin/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: "com.vanniktech.maven.publish"
 
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+}
+
 android {
     namespace "com.uber.rib.flipper"
     compileSdk deps.build.compileSdkVersion

--- a/android/tooling/rib-intellij-plugin/build.gradle
+++ b/android/tooling/rib-intellij-plugin/build.gradle
@@ -4,9 +4,12 @@ buildscript {
     }
 }
 
-apply plugin: "java"
 apply plugin: "org.jetbrains.intellij"
 apply plugin: "org.jetbrains.kotlin.jvm"
+
+kotlin {
+    jvmToolchain(11)
+}
 
 group "com.uber.rib"
 

--- a/android/tooling/utils/intellij-broadcast-core/build.gradle
+++ b/android/tooling/utils/intellij-broadcast-core/build.gradle
@@ -17,6 +17,12 @@
 apply plugin: 'com.android.library'
 apply plugin: "com.vanniktech.maven.publish"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.debug.broadcast.core"
     compileSdk deps.build.compileSdkVersion

--- a/android/tutorials/tutorial1/build.gradle
+++ b/android/tutorials/tutorial1/build.gradle
@@ -22,9 +22,16 @@ buildscript {
     }
 }
 
-apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'com.android.application'
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 apply plugin: 'net.ltgt.nullaway'
+apply plugin: 'net.ltgt.errorprone'
 
 android {
     namespace "com.uber.rib.tutorial1"

--- a/android/tutorials/tutorial2/build.gradle
+++ b/android/tutorials/tutorial2/build.gradle
@@ -22,8 +22,15 @@ buildscript {
     }
 }
 
-apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'com.android.application'
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'net.ltgt.nullaway'
 
 android {

--- a/android/tutorials/tutorial3-completed/build.gradle
+++ b/android/tutorials/tutorial3-completed/build.gradle
@@ -22,6 +22,12 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.rib.tutorial1"
     compileSdk deps.build.compileSdkVersion

--- a/android/tutorials/tutorial3/build.gradle
+++ b/android/tutorials/tutorial3/build.gradle
@@ -22,6 +22,12 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.rib.tutorial1"
     compileSdk deps.build.compileSdkVersion

--- a/android/tutorials/tutorial4/build.gradle
+++ b/android/tutorials/tutorial4/build.gradle
@@ -22,6 +22,12 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 android {
     namespace "com.uber.rib.tutorial4"
     compileSdk deps.build.compileSdkVersion


### PR DESCRIPTION
This allows for a more repeatable, predictable build between different local configurations.

On Kotlin modules, this is achieved by adding the following to project-level `build.gradle`:
```
kotlin {
  jvmToolchain(11)
}
```

On Java modules,

```
java {
  toolchain {
    languageVersion.set(JavaLanguageVersion.of(11))
  }
}
```

For non-Android Kotlin, when using the JVM Toolchain, the following is not needed anymore:
```
sourceCompatibility = deps.build.javaVersion.toString()
targetCompatibility = deps.build.javaVersion.toString()
```

For Android Kotlin modules, because of [a bug present in AGP 7.4.x up to 8.1.0-alpha08](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support), the following is still needed:
```
android {
    compileOptions {
        sourceCompatibility = <MAJOR_JDK_VERSION>
        targetCompatibility = <MAJOR_JDK_VERSION>
    }
}
```

Because AGP is bundled with the Android IntelliJ IDEA plugin, we cannot upgrade it (maximum supported version is 7.4 on 2023.1.1). We should open a new issue for removing above configuration block when a newer stable IntelliJ IDEA version ships with support for AGP 8.1.0.alpha09 or higher

Fixes #584 