### PR TITLE
Only complete the worker's scope after calling `Worker.onStop`

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -333,7 +333,6 @@ private fun <T : Comparable<T>> Worker.bind(
       lifecycle
         .takeWhile { it < lifecycleRange.endInclusive }
         .onCompletion {
-          completable.onComplete()
           bindAndReportWorkerInfo(
             workerDurationListenerWeakRef,
             WorkerEvent.STOP,
@@ -341,6 +340,7 @@ private fun <T : Comparable<T>> Worker.bind(
           ) {
             onStop()
           }
+          completable.onComplete()
         }
         .collect {
           bindAndReportWorkerInfo(


### PR DESCRIPTION
Some Workers might expect to do lifecycle-sensitive operations on `onStop`.