### PR TITLE
Deprecate existing WorkerBinder.bind methods and provide recommended bindTo methods with RibDispatchers.Default

### DIFF
--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
@@ -53,18 +53,18 @@ class RibWorkerSelectionInteractor(
         when (it) {
           RibWorkerBindTypeClickType.SINGLE_WORKER_BIND_CALLER_THREAD -> {
             updateViewModel(uiWorker::class.simpleName)
-            WorkerBinder.bind(this, uiWorker)
+            WorkerBinder.bindToInteractor(this, uiWorker)
           }
           RibWorkerBindTypeClickType.SINGLE_WORKER_BIND_BACKGROUND_THREAD -> {
             updateViewModel(ioWorker::class.simpleName)
-            WorkerBinder.bind(this, ioWorker)
+            WorkerBinder.bindToInteractor(this, ioWorker)
           }
           RibWorkerBindTypeClickType.BIND_MULTIPLE_WORKERS -> {
             val workers = listOf(backgroundWorker, defaultWorker, ioWorker, uiWorker)
             updateViewModel("Multiple workers ")
             // Given uiWorker specifies its CoroutineContext,
             // RibDispatchers.Main for Ui worker will remain besides Dispatchers.Default
-            WorkerBinder.bind(this, workers, RibDispatchers.Default)
+            WorkerBinder.bindToInteractor(this, workers)
           }
           RibWorkerBindTypeClickType.BIND_RIB_COROUTINE_WORKER -> {
             updateViewModel(defaultRibCoroutineWorker::class.simpleName)
@@ -78,7 +78,7 @@ class RibWorkerSelectionInteractor(
           RibWorkerBindTypeClickType.RIB_COROUTINE_WORKER_TO_WORKER -> {
             val worker = defaultRibCoroutineWorker.asWorker()
             updateViewModel(worker::class.simpleName)
-            WorkerBinder.bind(this, worker)
+            WorkerBinder.bindToInteractor(this, worker)
           }
         }
       }

--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
@@ -18,7 +18,7 @@ package com.uber.rib.workers.root.main.ribworkerselection
 import com.uber.rib.core.BasicInteractor
 import com.uber.rib.core.Bundle
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.WorkerBinder
+import com.uber.rib.core.WorkerBinder.bindTo
 import com.uber.rib.core.asRibCoroutineWorker
 import com.uber.rib.core.asWorker
 import com.uber.rib.core.bind
@@ -52,18 +52,18 @@ class RibWorkerSelectionInteractor(
         when (it) {
           RibWorkerBindTypeClickType.SINGLE_WORKER_BIND_CALLER_THREAD -> {
             updateViewModel(uiWorker::class.simpleName)
-            WorkerBinder.bindToInteractor(this, uiWorker)
+            uiWorker.bindTo(this)
           }
           RibWorkerBindTypeClickType.SINGLE_WORKER_BIND_BACKGROUND_THREAD -> {
             updateViewModel(ioWorker::class.simpleName)
-            WorkerBinder.bindToInteractor(this, ioWorker)
+            ioWorker.bindTo(this)
           }
           RibWorkerBindTypeClickType.BIND_MULTIPLE_WORKERS -> {
             val workers = listOf(backgroundWorker, defaultWorker, ioWorker, uiWorker)
             updateViewModel("Multiple workers ")
             // Given uiWorker specifies its CoroutineContext,
             // RibDispatchers.Main for Ui worker will remain besides Dispatchers.Default
-            WorkerBinder.bindToInteractor(this, workers)
+            workers.bindTo(this)
           }
           RibWorkerBindTypeClickType.BIND_RIB_COROUTINE_WORKER -> {
             updateViewModel(defaultRibCoroutineWorker::class.simpleName)
@@ -77,7 +77,7 @@ class RibWorkerSelectionInteractor(
           RibWorkerBindTypeClickType.RIB_COROUTINE_WORKER_TO_WORKER -> {
             val worker = defaultRibCoroutineWorker.asWorker()
             updateViewModel(worker::class.simpleName)
-            WorkerBinder.bindToInteractor(this, worker)
+            worker.bindTo(this)
           }
         }
       }

--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
@@ -18,7 +18,6 @@ package com.uber.rib.workers.root.main.ribworkerselection
 import com.uber.rib.core.BasicInteractor
 import com.uber.rib.core.Bundle
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.RibDispatchers
 import com.uber.rib.core.WorkerBinder
 import com.uber.rib.core.asRibCoroutineWorker
 import com.uber.rib.core.asWorker

--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
@@ -18,10 +18,10 @@ package com.uber.rib.workers.root.main.ribworkerselection
 import com.uber.rib.core.BasicInteractor
 import com.uber.rib.core.Bundle
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.WorkerBinder.bindTo
 import com.uber.rib.core.asRibCoroutineWorker
 import com.uber.rib.core.asWorker
 import com.uber.rib.core.bind
+import com.uber.rib.core.bindTo
 import com.uber.rib.core.coroutineScope
 import com.uber.rib.workers.root.main.workers.BackgroundWorker
 import com.uber.rib.workers.root.main.workers.DefaultRibCoroutineWorker

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -62,11 +62,12 @@ public object WorkerBinder {
   }
 
   /**
-   * Initializes [WorkerBinderMigrationProvider]
+   * Initializes [WorkerBinderMigrationProvider]. It will be used to allow changing the current
+   * default CoroutineDispatchers being bound from [RibDispatchers.Main] to [RibDispatchers.Default]
+   * at WorkerBinder.bind calls.
    *
-   * Provide a concrete implementation of [WorkerBinderMigrationProvider] that allow controlled
-   * changes (e.g. via remote configuration) for changing current default CoroutineDispatchers being
-   * bound from [RibDispatchers.Main] to [RibDispatchers.Default]
+   * This could be used within a remote configuration that will allow for a safe revert in case of
+   * issues detected (e.g. Specific Worker must be bound on main thread)
    *
    * IMPORTANT: If set, this should be called at the earliest scope possible to allow migrating
    * early workers
@@ -447,13 +448,18 @@ public fun interface WorkerBinderListener {
  * allow a safe migration (e.g. via remove config) and allowing to change the current
  * CoroutineDispatcher being used in WorkerBinder.bind calls from [CoroutineDispatchers.Unconfined]
  * to [RibDispatchers.Default]
+ *
+ * IMPORTANT NOTE: For calls to WorkerBinder.bind that receive a list of workers and one of the
+ * workers in the list requires to be bound on main thread, a concrete override can be applied on
+ * the Worker itself (e.g. by overriding default coroutineContext at Worker from
+ * [EmptyCoroutineContext] to [RibDispatchers.Main]
  */
 public fun interface WorkerBinderMigrationProvider {
 
   /**
-   * Returns true with true when the original default CoroutineDispatcher at WorkerBinder should be
-   * migrated to a background dispatcher (e.g. from [CoroutineDispatchers.Unconfined] to
-   * [RibDispatchers.Default])
+   * Returns true when the default CoroutineDispatcher ([CoroutineDispatchers.Unconfined]) at
+   * WorkerBinder should be migrated to a background dispatcher (e.g. from
+   * [CoroutineDispatchers.Unconfined] to [RibDispatchers.Default])
    */
   public fun shouldMigrateDispatcherAtWorkerBinder(): Boolean
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -72,7 +72,7 @@ public object WorkerBinder {
    * early workers
    */
   @JvmStatic
-  public fun initializeDispatcherMigration(
+  public fun initializeWorkerBinderMigration(
     workerBinderMigrationProvider: WorkerBinderMigrationProvider,
   ) {
     this.workerBinderMigrationProvider = workerBinderMigrationProvider

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -61,6 +61,46 @@ public object WorkerBinder {
 
   /**
    * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
+   * interactor's lifecycle events
+   *
+   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * overrides [coroutineContext] to other than [EmptyCoroutineContext]
+   *
+   * Inject this class into your interactor and call this method on any
+   *
+   * @param interactor The interactor that provides the lifecycle.
+   * @param worker The class that wants to be informed when to start and stop doing work.
+   * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
+   */
+  @JvmStatic
+  public fun bindToInteractor(
+    interactor: Interactor<*, *>,
+    worker: Worker,
+  ): WorkerUnbinder = bind(interactor, worker, RibDispatchers.Default)
+
+  /**
+   * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
+   * interactor's lifecycle events
+   *
+   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * overrides [coroutineContext] to other than [EmptyCoroutineContext]
+   *
+   * Inject this class into your interactor and call this method on any
+   *
+   * @param interactor The interactor that provides the lifecycle.
+   * @param workers A list of classes that want to be informed when to start and stop doing work.
+   * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
+   */
+  @JvmStatic
+  public fun bindToInteractor(
+    interactor: Interactor<*, *>,
+    workers: List<Worker>,
+  ) {
+    bind(interactor, workers, RibDispatchers.Default)
+  }
+
+  /**
+   * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
    * interactor's lifecycle events. Inject this class into your interactor and call this method on
    * any
    *
@@ -70,6 +110,14 @@ public object WorkerBinder {
    *   is not overriden with a value different that [EmptyCoroutineContext]
    * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
    */
+  @Deprecated(
+    message =
+      """
+      This method will bind on current thread where WorkerBinder is called. This often means that
+      the binding will happen on the main Thread leading to potential Jank issues/ANRs
+    """,
+    replaceWith = ReplaceWith("bindToInteractor(interactor, workers)"),
+  )
   @JvmStatic
   @JvmOverloads
   public fun bind(
@@ -95,6 +143,14 @@ public object WorkerBinder {
    *   [Worker.coroutineContext] is not overriden with a value different than
    *   [EmptyCoroutineContext]
    */
+  @Deprecated(
+    message =
+      """
+      This method will bind on current thread where WorkerBinder is called. This often means that
+      the binding will happen on the main Thread leading to potential Jank issues/ANRs
+    """,
+    replaceWith = ReplaceWith("bindToInteractor(interactor, workers)"),
+  )
   @JvmStatic
   @JvmOverloads
   public fun bind(
@@ -111,6 +167,42 @@ public object WorkerBinder {
    * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
    * presenter's lifecycle events. Inject this class into your presenter and call this method on any
    *
+   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * overrides [coroutineContext] to other than [EmptyCoroutineContext]
+   *
+   * @param presenter The presenter that provides the lifecycle.
+   * @param worker The class that wants to be informed when to start and stop doing work.
+   * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
+   */
+  @JvmStatic
+  public fun bindToPresenter(
+    presenter: Presenter,
+    worker: Worker,
+  ): WorkerUnbinder = bind(presenter, worker, RibDispatchers.Default)
+
+  /**
+   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
+   * presenter's lifecycle events. Inject this class into your presenter and call this method on any
+   *
+   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * overrides [coroutineContext] to other than [EmptyCoroutineContext]
+   *
+   * @param presenter The presenter that provides the lifecycle.
+   * @param workers A list of classes that want to be informed when to start and stop doing work.
+   * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
+   */
+  @JvmStatic
+  public fun bindToPresenter(
+    presenter: Presenter,
+    workers: List<Worker>,
+  ) {
+    bind(presenter, workers, RibDispatchers.Default)
+  }
+
+  /**
+   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
+   * presenter's lifecycle events. Inject this class into your presenter and call this method on any
+   *
    * @param presenter The presenter that provides the lifecycle.
    * @param worker The class that wants to be informed when to start and stop doing work.
    * @param dispatcherAtBinder CoroutineDispatcher to be applied only when the
@@ -118,6 +210,14 @@ public object WorkerBinder {
    *   [EmptyCoroutineContext]
    * @return [WorkerUnbinder] to unbind [Worker]'s lifecycle.
    */
+  @Deprecated(
+    message =
+      """
+      This method will bind on current thread where WorkerBinder is called. This often means that
+      the binding will happen on the main Thread leading to potential Jank issues/ANRs
+    """,
+    replaceWith = ReplaceWith("bindToPresenter(presenter, worker)"),
+  )
   @JvmStatic
   @JvmOverloads
   public fun bind(
@@ -143,7 +243,16 @@ public object WorkerBinder {
    *   [Worker.coroutineContext] is not overriden with a value different than
    *   [EmptyCoroutineContext]
    */
+  @Deprecated(
+    message =
+      """
+      This method will bind on current thread where WorkerBinder is called. This often means that
+      the binding will happen on the main Thread leading to potential Jank issues/ANRs
+    """,
+    replaceWith = ReplaceWith("bindToPresenter(presenter, workers)"),
+  )
   @JvmStatic
+  @JvmOverloads
   public fun bind(
     presenter: Presenter,
     workers: List<Worker>,

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -63,10 +63,8 @@ public object WorkerBinder {
    * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
    * interactor's lifecycle events
    *
-   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * IMPORTANT: Binding will happen on [RibDispatchers.Default] unless the Worker explicitly
    * overrides [coroutineContext] to other than [EmptyCoroutineContext]
-   *
-   * Inject this class into your interactor and call this method on any
    *
    * @param interactor The interactor that provides the lifecycle.
    * @param worker The class that wants to be informed when to start and stop doing work.
@@ -82,10 +80,8 @@ public object WorkerBinder {
    * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
    * interactor's lifecycle events
    *
-   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * IMPORTANT: Binding will happen on [RibDispatchers.Default] unless the Worker explicitly
    * overrides [coroutineContext] to other than [EmptyCoroutineContext]
-   *
-   * Inject this class into your interactor and call this method on any
    *
    * @param interactor The interactor that provides the lifecycle.
    * @param workers A list of classes that want to be informed when to start and stop doing work.
@@ -101,8 +97,7 @@ public object WorkerBinder {
 
   /**
    * Bind a worker (ie. a manager or any other class that needs an interactor's lifecycle) to an
-   * interactor's lifecycle events. Inject this class into your interactor and call this method on
-   * any
+   * interactor's lifecycle events.
    *
    * @param interactor The interactor that provides the lifecycle.
    * @param worker The class that wants to be informed when to start and stop doing work.
@@ -164,10 +159,10 @@ public object WorkerBinder {
   }
 
   /**
-   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
-   * presenter's lifecycle events. Inject this class into your presenter and call this method on any
+   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to a
+   * presenter's lifecycle events.
    *
-   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * IMPORTANT: Binding will happen on [RibDispatchers.Default] unless the Worker explicitly
    * overrides [coroutineContext] to other than [EmptyCoroutineContext]
    *
    * @param presenter The presenter that provides the lifecycle.
@@ -181,10 +176,10 @@ public object WorkerBinder {
   ): WorkerUnbinder = bind(presenter, worker, RibDispatchers.Default)
 
   /**
-   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
-   * presenter's lifecycle events. Inject this class into your presenter and call this method on any
+   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to a
+   * presenter's lifecycle events.
    *
-   * IMPORTANT: Binding will happen on [RibDispatchers.DEFAULT] unless the Worker explicitly
+   * IMPORTANT: Binding will happen on [RibDispatchers.Default] unless the Worker explicitly
    * overrides [coroutineContext] to other than [EmptyCoroutineContext]
    *
    * @param presenter The presenter that provides the lifecycle.
@@ -200,8 +195,8 @@ public object WorkerBinder {
   }
 
   /**
-   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to an
-   * presenter's lifecycle events. Inject this class into your presenter and call this method on any
+   * Bind a worker (ie. a manager or any other class that needs an presenter's lifecycle) to a
+   * presenter's lifecycle events.
    *
    * @param presenter The presenter that provides the lifecycle.
    * @param worker The class that wants to be informed when to start and stop doing work.
@@ -234,7 +229,7 @@ public object WorkerBinder {
 
   /**
    * Bind a list of workers (ie. a manager or any other class that needs an presenter's lifecycle)
-   * to an presenter's lifecycle events. Use this class into your presenter and call this method on
+   * to a presenter's lifecycle events. Use this class into your presenter and call this method on
    * attach.
    *
    * @param presenter The presenter that provides the lifecycle.

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -18,6 +18,7 @@ package com.uber.rib.core
 import com.google.common.truth.Truth.assertThat
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.uber.rib.core.WorkerBinder.bind
+import com.uber.rib.core.WorkerBinder.bindToInteractor
 import com.uber.rib.core.WorkerBinder.bindToWorkerLifecycle
 import com.uber.rib.core.WorkerBinder.mapInteractorLifecycleToWorker
 import com.uber.rib.core.WorkerBinder.mapPresenterLifecycleToWorker
@@ -181,6 +182,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   fun bind_withUnconfinedCoroutineDispatchers_shouldReportBinderInformationForOnStart() = runTest {
     val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
     bindFakeWorker()
+    advanceUntilIdle()
     verify(workerBinderListener).onBindCompleted(binderDurationCaptor.capture())
     binderDurationCaptor.firstValue.assertWorkerDuration(
       "FakeWorker",
@@ -195,7 +197,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
     val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
     prepareInteractor()
     val workers = listOf(fakeWorker, fakeWorker, uiWorker)
-    bind(interactor, workers)
+    bindToInteractor(interactor, workers)
     advanceUntilIdle()
     verify(workerBinderListener, times(3)).onBindCompleted(binderDurationCaptor.capture())
     binderDurationCaptor.firstValue.assertWorkerDuration(
@@ -214,7 +216,9 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   fun unbind_withUnconfinedCoroutineDispatchers_shouldReportBinderDurationForOnStop() = runTest {
     val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
     val unbinder = bindFakeWorker()
+    advanceUntilIdle()
     unbinder.unbind()
+    advanceUntilIdle()
     verify(workerBinderListener, times(2)).onBindCompleted(binderDurationCaptor.capture())
     binderDurationCaptor.secondValue.assertWorkerDuration(
       "FakeWorker",
@@ -225,7 +229,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
 
   private fun bindFakeWorker(): WorkerUnbinder {
     prepareInteractor()
-    return bind(interactor, fakeWorker)
+    return bindToInteractor(interactor, fakeWorker)
   }
 
   private fun prepareInteractor() {

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -18,7 +18,6 @@ package com.uber.rib.core
 import com.google.common.truth.Truth.assertThat
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.uber.rib.core.WorkerBinder.bind
-import com.uber.rib.core.WorkerBinder.bindTo
 import com.uber.rib.core.WorkerBinder.bindToWorkerLifecycle
 import com.uber.rib.core.WorkerBinder.mapInteractorLifecycleToWorker
 import com.uber.rib.core.WorkerBinder.mapPresenterLifecycleToWorker

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -64,7 +64,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   @Before
   fun setUp() {
     WorkerBinder.initializeMonitoring(workerBinderListener)
-    WorkerBinder.initializeDispatcherMigration(fakeWorkerBinderThreadMigrationProvider)
+    WorkerBinder.initializeWorkerBinderMigration(fakeWorkerBinderThreadMigrationProvider)
   }
 
   @Test

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -56,6 +56,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
       }
     }
   private val workerBinderListener: WorkerBinderListener = mock()
+  private val fakeWorkerBinderThreadMigrationProvider = FakeWorkerBinderMigrationProvider()
 
   private val fakeWorker = FakeWorker()
   private val interactor = FakeInteractor<Presenter, Router<*>>()
@@ -63,6 +64,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   @Before
   fun setUp() {
     WorkerBinder.initializeMonitoring(workerBinderListener)
+    WorkerBinder.initializeDispatcherMigration(fakeWorkerBinderThreadMigrationProvider)
   }
 
   @Test
@@ -192,6 +194,20 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   }
 
   @Test
+  fun bind_withMigrationEnabled_shouldBindOnRibDispatchersDefault() = runTest {
+    val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
+    prepareInteractor()
+    bind(interactor, fakeWorker)
+    advanceUntilIdle()
+    verify(workerBinderListener).onBindCompleted(binderDurationCaptor.capture())
+    binderDurationCaptor.firstValue.assertWorkerDuration(
+      "FakeWorker",
+      WorkerEvent.START,
+      RibDispatchers.Default,
+    )
+  }
+
+  @Test
   fun bind_multipleWorkers_shouldReportBinderTwice() = runTest {
     val uiWorker = UiWorker()
     val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
@@ -263,4 +279,10 @@ private fun Worker(onStartBlock: (WorkerScopeProvider) -> Unit) =
 
 class UiWorker : Worker {
   override val coroutineContext: CoroutineDispatcher = RibDispatchers.Main
+}
+
+class FakeWorkerBinderMigrationProvider : WorkerBinderMigrationProvider {
+  private var isMigrationEnabled = false
+
+  override fun shouldMigrateDispatcherAtWorkerBinder(): Boolean = isMigrationEnabled
 }


### PR DESCRIPTION
<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

Since https://github.com/uber/RIBs/pull/553 we added support to specify on which CoroutineDispatcher are presidio Worker will be bound. RibDispatchers.Unconfined was added as a default parameter in order to keep existing behavior and not be a breaking change. 

Still, binding by default on the current caller thread within interactor means that by default we are binding workers on main UI thread leading to potential jank ANR etc just for binding those workers. 

This is specially problematic when the list of workers being bound keeps increasing (e.g. hypothetically if we have 100 workers and each bind takes at least 50 ms this will result on the UI thread being blocked for at least 5000ms)

Proposal is to deprecate existing methods and provide new methods that by default will bind on **Ribdispatchers.DEFAULT** (similarly to **RibCoroutineWorker**). Still if there is a need for a Worker to change the thread where it will be bound we can rely on **coroutineContext** property to be overriden as following (default value is **EmptyCoroutineContext**):

```
  class MyUiWorker:com.uber.rib.core.Worker{
    override val coroutineContext: CoroutineContext = RibDispatchers.Main
  }
```

Demo call:

`worker.bindTo(interactor)
`

NOTE: For calling on existing java files -> `WorkerBinderKt.bindTo(ribWorker, this));`

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

https://github.com/uber/RIBs/issues/595

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->

Verified via Unit tests
