### PR TITLE
Allow overriding default CoroutineDispatcher for WorkerBinder calls

### DIFF
--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/ribworkerselection/RibWorkerSelectionInteractor.kt
@@ -18,7 +18,6 @@ package com.uber.rib.workers.root.main.ribworkerselection
 import com.uber.rib.core.BasicInteractor
 import com.uber.rib.core.Bundle
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.RibDispatchers
 import com.uber.rib.core.WorkerBinder
 import com.uber.rib.core.asRibCoroutineWorker
 import com.uber.rib.core.asWorker
@@ -62,9 +61,7 @@ class RibWorkerSelectionInteractor(
           RibWorkerBindTypeClickType.BIND_MULTIPLE_WORKERS -> {
             val workers = listOf(backgroundWorker, defaultWorker, ioWorker, uiWorker)
             updateViewModel("Multiple workers ")
-            // Given uiWorker specifies its CoroutineContext,
-            // RibDispatchers.Main for Ui worker will remain besides Dispatchers.Default
-            WorkerBinder.bind(this, workers, RibDispatchers.Default)
+            WorkerBinder.bind(this, workers)
           }
           RibWorkerBindTypeClickType.BIND_RIB_COROUTINE_WORKER -> {
             updateViewModel(defaultRibCoroutineWorker::class.simpleName)

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -62,7 +62,6 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   @Before
   fun setUp() {
     WorkerBinder.initializeMonitoring(workerBinderListener)
-    WorkerBinder.updateDispatcher { RibDispatchers.Unconfined }
   }
 
   @Test
@@ -224,20 +223,6 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
     )
   }
 
-  @Test
-  fun bind_withUpdatedWorkerBinderDispatcher_shouldBindOnRibDispatchersDefault() = runTest {
-    val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
-    WorkerBinder.updateDispatcher { RibDispatchers.Default }
-    prepareInteractor()
-    bind(interactor, fakeWorker)
-    advanceUntilIdle()
-    verify(workerBinderListener).onBindCompleted(binderDurationCaptor.capture())
-    binderDurationCaptor.firstValue.assertWorkerDuration(
-      "FakeWorker",
-      WorkerEvent.START,
-      RibDispatchers.Default,
-    )
-  }
   private fun bindFakeWorker(): WorkerUnbinder {
     prepareInteractor()
     return bind(interactor, fakeWorker)

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerBinderTest.kt
@@ -62,6 +62,7 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
   @Before
   fun setUp() {
     WorkerBinder.initializeMonitoring(workerBinderListener)
+    WorkerBinder.updateDispatcher { RibDispatchers.Unconfined }
   }
 
   @Test
@@ -223,6 +224,20 @@ class WorkerBinderTest(private val adaptFromRibCoroutineWorker: Boolean) {
     )
   }
 
+  @Test
+  fun bind_withUpdatedWorkerBinderDispatcher_shouldBindOnRibDispatchersDefault() = runTest {
+    val binderDurationCaptor = argumentCaptor<WorkerBinderInfo>()
+    WorkerBinder.updateDispatcher { RibDispatchers.Default }
+    prepareInteractor()
+    bind(interactor, fakeWorker)
+    advanceUntilIdle()
+    verify(workerBinderListener).onBindCompleted(binderDurationCaptor.capture())
+    binderDurationCaptor.firstValue.assertWorkerDuration(
+      "FakeWorker",
+      WorkerEvent.START,
+      RibDispatchers.Default,
+    )
+  }
   private fun bindFakeWorker(): WorkerUnbinder {
     prepareInteractor()
     return bind(interactor, fakeWorker)

--- a/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutinesConfig.kt
+++ b/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutinesConfig.kt
@@ -37,4 +37,21 @@ public object RibCoroutinesConfig {
    * [Thread.UncaughtExceptionHandler].
    */
   @JvmStatic public var exceptionHandler: CoroutineExceptionHandler? = null
+
+  /**
+   * Specify the [CoroutineDispatcher] to be used while binding a [com.uber.rib.Worker] via
+   * [WorkerBinder]
+   *
+   * IMPORTANT: This shouldn't be used outside [WorkerBinder] given that [WorkerBinder]/[Worker] are
+   * deprecated
+   */
+  @Deprecated(
+    message =
+      """
+      This dispatcher is only intended to be used within the [com.uber.rib.core.WorkerBinder].
+      For adding and binding new RIB workers please use [RibCoroutineWorker]
+      """,
+  )
+  @JvmStatic
+  public var deprecatedWorkerDispatcher: CoroutineDispatcher = RibDispatchers.Unconfined
 }


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
WorkerBinder/Worker is going away in favor of RibCoroutineWorker. Still we would like to provide a mechanism to change the default CoroutineDispatcher being used at WorkerBinder.bind calls to be other than Unconfined. 

This is given that the effective threading for binding those calls happens on the main thread, potentially leading to Jank, ANR, freezes, etc.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

Current Workers being bound on Main thread. 

**Verification**:

- Verified on rib-workers demo app
![image](https://github.com/uber/RIBs/assets/4230063/e2b2b4f7-65b3-4b49-9f34-23087005270c)

- Existing JUnit tests

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
