### PR TITLE
Deprecate old worker

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Worker.kt
@@ -31,6 +31,13 @@ import kotlinx.coroutines.CoroutineDispatcher
  * RibDispatchers.Default) from [Worker] will take priority over the one passed via a
  * [WorkerBinder.bind] call
  */
+@Deprecated(
+  message =
+    """
+      [com.uber.rib.core.Worker] is deprecated in favor of [com.uber.rib.core.RibCoroutineWorker]
+    """,
+  replaceWith = ReplaceWith("RibCoroutineWorker"),
+)
 public interface Worker {
 
   /**

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -44,6 +44,13 @@ private val Worker.bindingCoroutineContext: CoroutineContext
   get() = this.coroutineContext ?: EmptyCoroutineContext
 
 /** Helper class to bind to an interactor's lifecycle to translate it to a [Worker] lifecycle. */
+@Deprecated(
+  message =
+    """
+      [com.uber.rib.core.Worker] is deprecated in favor of [com.uber.rib.core.RibCoroutineWorker]
+    """,
+  replaceWith = ReplaceWith("For binding a RibCoroutineWorker use its .bind extension function"),
+)
 public object WorkerBinder {
 
   private var workerBinderListenerWeakRef: WeakReference<WorkerBinderListener>? = null


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->

**Description**:

Deprecate existing com.uber.rib.Worker in favor of RibCoroutineWorker

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/RIBs/issues/595

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
