### PR TITLE
Set view tree owners

### DIFF
--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/RootScope.kt
@@ -16,8 +16,6 @@
 package com.uber.rib.compose.root
 
 import android.view.ViewGroup
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.compose.root.main.MainScope
 import com.uber.rib.compose.util.AnalyticsClient
 import com.uber.rib.compose.util.AnalyticsClientImpl
@@ -43,11 +41,8 @@ interface RootScope {
 
     abstract fun presenter(): EmptyPresenter
 
-    fun view(parentViewGroup: ViewGroup, activity: RibActivity): RootView {
-      return RootView(parentViewGroup.context).apply {
-        setViewTreeLifecycleOwner(activity)
-        setViewTreeSavedStateRegistryOwner(activity)
-      }
+    fun view(parentViewGroup: ViewGroup): RootView {
+      return RootView(parentViewGroup.context)
     }
 
     @Expose

--- a/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
+++ b/android/demos/compose/src/main/kotlin/com/uber/rib/compose/root/main/MainScope.kt
@@ -19,15 +19,12 @@ import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.platform.ComposeView
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.compose.root.main.loggedin.LoggedInScope
 import com.uber.rib.compose.root.main.loggedout.LoggedOutScope
 import com.uber.rib.compose.util.AnalyticsClient
 import com.uber.rib.compose.util.ExperimentClient
 import com.uber.rib.compose.util.LoggerClient
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.RibActivity
 import motif.Expose
 
 @motif.Scope
@@ -55,15 +52,8 @@ interface MainScope {
       }
     }
 
-    fun view(
-      parentViewGroup: ViewGroup,
-      activity: RibActivity,
-      presenter: ComposePresenter,
-    ): ComposeView {
-      return ComposeView(parentViewGroup.context).apply {
-        setViewTreeLifecycleOwner(activity)
-        setViewTreeSavedStateRegistryOwner(activity)
-      }
+    fun view(parentViewGroup: ViewGroup): ComposeView {
+      return ComposeView(parentViewGroup.context)
     }
 
     abstract fun childContent(): MainRouter.ChildContent

--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/RootScope.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/RootScope.kt
@@ -16,10 +16,7 @@
 package com.uber.rib.workers.root
 
 import android.view.ViewGroup
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.core.EmptyPresenter
-import com.uber.rib.core.RibActivity
 import com.uber.rib.workers.root.main.MainScope
 
 @motif.Scope
@@ -36,11 +33,8 @@ interface RootScope {
 
     abstract fun presenter(): EmptyPresenter
 
-    fun view(parentViewGroup: ViewGroup, activity: RibActivity): RootView {
-      return RootView(parentViewGroup.context).apply {
-        setViewTreeLifecycleOwner(activity)
-        setViewTreeSavedStateRegistryOwner(activity)
-      }
+    fun view(parentViewGroup: ViewGroup): RootView {
+      return RootView(parentViewGroup.context)
     }
   }
 }

--- a/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/MainScope.kt
+++ b/android/demos/rib-workers/src/main/kotlin/com/uber/rib/workers/root/main/MainScope.kt
@@ -19,10 +19,7 @@ import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.platform.ComposeView
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.uber.rib.core.ComposePresenter
-import com.uber.rib.core.RibActivity
 import com.uber.rib.workers.root.main.ribworkerselection.RibWorkerSelectionScope
 
 @motif.Scope
@@ -45,15 +42,8 @@ interface MainScope {
       }
     }
 
-    fun view(
-      parentViewGroup: ViewGroup,
-      activity: RibActivity,
-      presenter: ComposePresenter,
-    ): ComposeView {
-      return ComposeView(parentViewGroup.context).apply {
-        setViewTreeLifecycleOwner(activity)
-        setViewTreeSavedStateRegistryOwner(activity)
-      }
+    fun view(parentViewGroup: ViewGroup): ComposeView {
+      return ComposeView(parentViewGroup.context)
     }
 
     abstract fun childContent(): MainRouter.ChildContent

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ android-api = "4.1.1.4"
 androidx-activity = "1.7.0"
 androidx-annotations = "1.1.0"
 androidx-appcompat = "1.3.0"
-androidx-lifecycle = "2.5.1"
+androidx-lifecycle = "2.6.1"
 autocommon = "0.8"
 autodispose = "1.4.0"
 autoservice = "1.0-rc4"
@@ -95,6 +95,7 @@ javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
 jsr250 = { group = "javax.annotation", name = "jsr250-api", version.ref = "jsr250" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
+lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidx-lifecycle" }
 motif-compiler = { group = "com.uber.motif", name = "motif-compiler", version.ref = "motif" }
 motif-library = { group = "com.uber.motif", name = "motif", version.ref = "motif" }
 percent = { group = "androidx.percentlayout", name = "percentlayout", version.ref = "percent" }

--- a/android/libraries/rib-android/build.gradle
+++ b/android/libraries/rib-android/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.coroutines.rx2)
     testImplementation(testLibs.robolectric)
+    testImplementation(libs.lifecycle.runtime)
     testImplementation(libs.appcompat)
     testImplementation(testLibs.mockitoKotlin)
     testImplementation(project(":libraries:rib-test"))

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -22,6 +22,9 @@ import android.content.res.Configuration
 import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.ViewTreeViewModelStoreOwner
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleNotStartedException
@@ -90,6 +93,7 @@ abstract class RibActivity :
   @CallSuper
   override fun onCreate(savedInstanceState: android.os.Bundle?) {
     super.onCreate(savedInstanceState)
+    initViewTreeOwners()
     val rootViewGroup = findViewById<ViewGroup>(android.R.id.content)
     _lifecycleFlow.tryEmit(createOnCreateEvent(savedInstanceState))
     val wrappedBundle: Bundle? =
@@ -231,6 +235,18 @@ abstract class RibActivity :
    * @return the [Interactor].
    */
   protected abstract fun createRouter(parentViewGroup: ViewGroup): ViewRouter<*, *>
+
+  /**
+   * [RibActivity] must call this since it does not use [ComponentActivity.setContentView] which
+   * already handles this.
+   */
+  private fun initViewTreeOwners() {
+    // Set the view tree owners before setting the content view so that the inflation process
+    // and attach listeners will see them already present
+    ViewTreeLifecycleOwner.set(window.decorView, this)
+    ViewTreeViewModelStoreOwner.set(window.decorView, this)
+    ViewTreeSavedStateRegistryOwner.set(window.decorView, this)
+  }
 
   companion object {
     /**

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.uber.autodispose.AutoDispose
 import com.uber.autodispose.lifecycle.LifecycleEndedException
@@ -187,6 +188,17 @@ class RibActivityTest {
   fun getController() {
     val activity: RibActivity = Robolectric.setupActivity(EmptyActivity::class.java)
     assertThat(activity.interactor).isNotNull()
+  }
+
+  @Test
+  fun onCreate_setsViewTreeOwners() {
+    val activity = Robolectric.buildActivity(EmptyActivity::class.java).create(null).get()
+    assertThat(activity.window.decorView.findViewTreeLifecycleOwner()).isNotNull()
+
+    val contentView = activity.findViewById<FrameLayout>(android.R.id.content)
+    val rootView = View(RuntimeEnvironment.application)
+    contentView.addView(rootView)
+    assertThat(rootView.findViewTreeLifecycleOwner()).isNotNull()
   }
 
   @Test(expected = IllegalArgumentException::class)

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/RibActivityTest.kt
@@ -21,6 +21,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import com.google.common.truth.Truth.assertThat
 import com.uber.autodispose.AutoDispose
 import com.uber.autodispose.lifecycle.LifecycleEndedException
@@ -191,14 +193,23 @@ class RibActivityTest {
   }
 
   @Test
-  fun onCreate_setsViewTreeOwners() {
+  fun onCreate_setsViewTreeOwners_forDecorView() {
     val activity = Robolectric.buildActivity(EmptyActivity::class.java).create(null).get()
-    assertThat(activity.window.decorView.findViewTreeLifecycleOwner()).isNotNull()
+    val decorView = activity.window.decorView
+    assertThat(decorView.findViewTreeLifecycleOwner()).isNotNull()
+    assertThat(decorView.findViewTreeSavedStateRegistryOwner()).isNotNull()
+    assertThat(decorView.findViewTreeViewModelStoreOwner()).isNotNull()
+  }
 
+  @Test
+  fun onCreate_setsViewTreeOwners_forViewAddedToDecorView() {
+    val activity = Robolectric.buildActivity(EmptyActivity::class.java).create(null).get()
     val contentView = activity.findViewById<FrameLayout>(android.R.id.content)
     val rootView = View(RuntimeEnvironment.application)
     contentView.addView(rootView)
     assertThat(rootView.findViewTreeLifecycleOwner()).isNotNull()
+    assertThat(rootView.findViewTreeSavedStateRegistryOwner()).isNotNull()
+    assertThat(rootView.findViewTreeViewModelStoreOwner()).isNotNull()
   }
 
   @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
Set view tree owners in `RibActivity#onCreate`. Since it adds the root RIB's view to the `android.R.id.content` view using `Activity#addView(View)` instead of calling [AppCompatActivity#setContentView(View)](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatActivity.java;l=202?q=appcompatactivity&ss=androidx) which already handles this.