### PR TITLE
Improve XRay implementation

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
@@ -34,7 +34,7 @@ abstract class ViewRouter<V : View, I : Interactor<*, *>> : Router<I> {
   ) : super(interactor, component) {
     this.view = view
     if (XRay.isEnabled()) {
-      XRay.apply(this, view)
+      XRay.apply(getName(), view)
     }
   }
 
@@ -44,7 +44,7 @@ abstract class ViewRouter<V : View, I : Interactor<*, *>> : Router<I> {
   ) : super(null, interactor, RibRefWatcher.getInstance(), getMainThread()) {
     this.view = view
     if (XRay.isEnabled()) {
-      XRay.apply(this, view)
+      XRay.apply(getName(), view)
     }
   }
 

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/XRayConfig.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/XRayConfig.kt
@@ -1,0 +1,11 @@
+package com.uber.rib.core
+
+/**
+ * Configuration for XRay.
+ * @property enabled `true` to enable XRay. By default it is disabled.
+ * @property alphaEnabled `true` to enable alpha changes when XRay is enabled.
+ */
+public data class XRayConfig(
+    val enabled: Boolean = false,
+    val alphaEnabled: Boolean = true,
+)

--- a/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/XRayTest.kt
+++ b/android/libraries/rib-android/src/test/kotlin/com/uber/rib/core/XRayTest.kt
@@ -16,27 +16,62 @@
 package com.uber.rib.core
 
 import android.view.View
-import com.uber.rib.core.XRay.Companion.apply
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class XRayTest {
+  @Before
+  fun setup() {
+    XRay.setup(XRayConfig(enabled = true))
+  }
+
+  @Test
+  fun test_initial_value() {
+    XRay.setup(XRayConfig())
+    assertFalse("XRay must be disabled by default", XRay.isEnabled())
+  }
 
   @Test
   fun apply_changesViewBackground() {
-    XRay.toggle()
-    val viewRouter: ViewRouter<*, *> = mock()
     val view: View = mock { on { context } doReturn (RuntimeEnvironment.application.baseContext) }
-    apply(viewRouter, view)
+    XRay.apply("Test", view)
     verify(view).background = any()
-    verifyNoMoreInteractions(viewRouter)
+    verify(view).alpha = 0.9f
+  }
+
+  @Test
+  fun apply_changesViewBackground_alphaDisabled() {
+    XRay.setup(XRayConfig(enabled = true, alphaEnabled = false))
+    val view: View = mock { on { context } doReturn (RuntimeEnvironment.application.baseContext) }
+    XRay.apply("Test", view)
+    verify(view).background = any()
+    verify(view, never()).alpha = any()
+  }
+
+  @Test
+  fun getShortRibletName_mustShortRouterName() {
+    assertEquals("Test", XRay.getShortRibletName("TestRouter"))
+    assertEquals("Router", XRay.getShortRibletName("Router"))
+  }
+
+  @Test
+  fun xray_toggle() {
+    XRay.toggle()
+    assertFalse(XRay.isEnabled())
+
+    XRay.toggle()
+    assertTrue(XRay.isEnabled())
   }
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
@@ -63,6 +63,13 @@ protected constructor(
   }
 
   /**
+   * @return the name of the router. This is used for logging and debugging purposes.
+   */
+  protected fun getName(): String {
+    return javaClass.simpleName
+  }
+
+  /**
    * Dispatch back press to the associated interactor. Do not override this.
    *
    * @return TRUE if the interactor handles the back press.
@@ -125,8 +132,8 @@ protected constructor(
 
     ribRefWatcher.logBreadcrumb(
       "ATTACHED",
-      childRouter.javaClass.simpleName,
-      this.javaClass.simpleName,
+      childRouter.getName(),
+      this.getName(),
     )
     RibEvents.emitRouterEvent(RibEventType.ATTACHED, childRouter, this)
     var childBundle: Bundle? = null
@@ -153,8 +160,8 @@ protected constructor(
     ribRefWatcher.watchDeletedObject(interactor)
     ribRefWatcher.logBreadcrumb(
       "DETACHED",
-      childRouter.javaClass.simpleName,
-      this.javaClass.simpleName,
+      childRouter.getName(),
+      this.getName(),
     )
     if (savedInstanceState != null) {
       val childrenBundles = savedInstanceState?.getBundleExtra(KEY_CHILD_ROUTERS)


### PR DESCRIPTION
**Description**:
This PR adds `setup()`, `XRayConfig` to RIBs XRay to allow setup it without rely on the existing `toggle()` function.

** Problem it fixes **
The current `toggle()` function may be problematic because it changes a static boolean. Example: depending on where XRay is enabled or if it's as debug in a RIB used twice, it will enabled and disable immediately.

`XRayConfig` adds the ability to enable XRay without change the Views alpha. The alpha change may be problematic when we have many RIBs attached due to the overlapping.


