### PR TITLE
Set view tree owners in parent class

### DIFF
--- a/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/CoreAppCompatActivity.kt
+++ b/android/libraries/rib-android-core/src/main/kotlin/com/uber/rib/core/CoreAppCompatActivity.kt
@@ -20,6 +20,9 @@ import android.os.Bundle
 import androidx.annotation.CallSuper
 import androidx.annotation.IntRange
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.ViewTreeViewModelStoreOwner
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 
 /** Core Support v7 AppCompat Activity. */
 abstract class CoreAppCompatActivity : AppCompatActivity() {
@@ -32,6 +35,7 @@ abstract class CoreAppCompatActivity : AppCompatActivity() {
       activityDelegate = (applicationContext as HasActivityDelegate).activityDelegate()
     }
     super.onCreate(savedInstanceState)
+    initViewTreeOwners()
     activityDelegate?.onCreate(savedInstanceState)
   }
 
@@ -80,5 +84,17 @@ abstract class CoreAppCompatActivity : AppCompatActivity() {
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     activityDelegate?.onActivityResult(this, requestCode, resultCode, data)
+  }
+
+  /**
+   * [RibActivity] must call this since it does not use [ComponentActivity.setContentView] which
+   * already handles this.
+   */
+  private fun initViewTreeOwners() {
+    // Set the view tree owners before setting the content view so that the inflation process
+    // and attach listeners will see them already present
+    ViewTreeLifecycleOwner.set(window.decorView, this)
+    ViewTreeViewModelStoreOwner.set(window.decorView, this)
+    ViewTreeSavedStateRegistryOwner.set(window.decorView, this)
   }
 }

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -22,9 +22,6 @@ import android.content.res.Configuration
 import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
-import androidx.lifecycle.ViewTreeLifecycleOwner
-import androidx.lifecycle.ViewTreeViewModelStoreOwner
-import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleNotStartedException
@@ -93,7 +90,6 @@ abstract class RibActivity :
   @CallSuper
   override fun onCreate(savedInstanceState: android.os.Bundle?) {
     super.onCreate(savedInstanceState)
-    initViewTreeOwners()
     val rootViewGroup = findViewById<ViewGroup>(android.R.id.content)
     _lifecycleFlow.tryEmit(createOnCreateEvent(savedInstanceState))
     val wrappedBundle: Bundle? =
@@ -235,18 +231,6 @@ abstract class RibActivity :
    * @return the [Interactor].
    */
   protected abstract fun createRouter(parentViewGroup: ViewGroup): ViewRouter<*, *>
-
-  /**
-   * [RibActivity] must call this since it does not use [ComponentActivity.setContentView] which
-   * already handles this.
-   */
-  private fun initViewTreeOwners() {
-    // Set the view tree owners before setting the content view so that the inflation process
-    // and attach listeners will see them already present
-    ViewTreeLifecycleOwner.set(window.decorView, this)
-    ViewTreeViewModelStoreOwner.set(window.decorView, this)
-    ViewTreeSavedStateRegistryOwner.set(window.decorView, this)
-  }
 
   companion object {
     /**


### PR DESCRIPTION
A followup to #606 which moves the logic into the superclass so all `CoreAppCompatActivity` subclasses benefit from the updated logic