### PR TITLE
Get rid of suppressions for "invisible_reference" and "invisible_member"

### DIFF
--- a/android/libraries/rib-android/build.gradle.kts
+++ b/android/libraries/rib-android/build.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("ribs.kotlin-android-library-conventions")
+    alias(libs.plugins.mavenPublish)
+}
+
+android {
+    namespace = "com.uber.rib.android"
+}
+
+kotlin {
+    sourceSets {
+        configureEach {
+            languageSettings {
+                optIn("com.uber.rib.core.internal.CoreFriendModuleApi")
+            }
+        }
+    }
+}
+
+dependencies {
+    api(project(":libraries:rib-android-core"))
+    api(project(":libraries:rib-base"))
+    api(libs.rxkotlin)
+    api(libs.rxrelay2)
+    api(libs.rxjava2)
+    implementation(libs.javax.inject)
+    implementation(libs.annotation)
+    implementation(libs.appcompat)
+    implementation(libs.guava.android)
+    implementation(libs.autodispose.coroutines)
+    implementation(libs.coroutines.android)
+    implementation(libs.coroutines.rx2)
+    testImplementation(testLibs.robolectric)
+    testImplementation(libs.lifecycle.runtime)
+    testImplementation(libs.appcompat)
+    testImplementation(testLibs.mockitoKotlin)
+    testImplementation(project(":libraries:rib-test"))
+}

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.core
 
 import android.content.Intent
@@ -45,7 +43,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.rx2.asObservable
 
 /** Base implementation for all VIP [android.app.Activity]s. */
-abstract class RibActivity :
+public abstract class RibActivity :
   CoreAppCompatActivity(),
   ActivityStarter,
   LifecycleScopeProvider<ActivityLifecycleEvent>,
@@ -55,7 +53,7 @@ abstract class RibActivity :
   private val _lifecycleFlow =
     MutableSharedFlow<ActivityLifecycleEvent>(1, 0, BufferOverflow.DROP_OLDEST)
 
-  open val lifecycleFlow: SharedFlow<ActivityLifecycleEvent>
+  public open val lifecycleFlow: SharedFlow<ActivityLifecycleEvent>
     get() = _lifecycleFlow
 
   @Volatile private var _lifecycleObservable: Observable<ActivityLifecycleEvent>? = null
@@ -64,7 +62,7 @@ abstract class RibActivity :
 
   private val _callbacksFlow =
     MutableSharedFlow<ActivityCallbackEvent>(0, 1, BufferOverflow.DROP_OLDEST)
-  open val callbacksFlow: SharedFlow<ActivityCallbackEvent>
+  public open val callbacksFlow: SharedFlow<ActivityCallbackEvent>
     get() = _callbacksFlow
 
   @Volatile private var _callbacksObservable: Observable<ActivityCallbackEvent>? = null
@@ -215,7 +213,7 @@ abstract class RibActivity :
    * @return the [Interactor] when the activity has alive.
    * @throws IllegalStateException if the activity has not been created or has been destroyed.
    */
-  open val interactor: Interactor<*, *>
+  public open val interactor: Interactor<*, *>
     get() =
       if (router != null) {
         router?.interactor as Interactor<*, *>
@@ -232,7 +230,7 @@ abstract class RibActivity :
    */
   protected abstract fun createRouter(parentViewGroup: ViewGroup): ViewRouter<*, *>
 
-  companion object {
+  public companion object {
     /**
      * Figures out which corresponding next lifecycle event in which to unsubscribe, for Activities.
      */

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
@@ -19,6 +19,7 @@ package com.uber.rib.core
 
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleNotStartedException
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import io.reactivex.CompletableSource
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -36,7 +37,8 @@ import kotlinx.coroutines.rx2.rxCompletable
  * 2. [LifecycleEndedException], if the last emitted event is in the end (inclusive) or beyond
  *    [range].
  */
-internal fun <T : Comparable<T>> SharedFlow<T>.asScopeCompletable(
+@CoreFriendModuleApi
+public fun <T : Comparable<T>> SharedFlow<T>.asScopeCompletable(
   range: ClosedRange<T>,
   context: CoroutineContext = EmptyCoroutineContext,
 ): CompletableSource {

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -20,6 +20,7 @@ import androidx.annotation.VisibleForTesting
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.rib.core.RibEvents.triggerRibActionAndEmitEvents
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import com.uber.rib.core.lifecycle.InteractorEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
@@ -39,12 +40,15 @@ import kotlinx.coroutines.rx2.asObservable
  */
 public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, RibActionEmitter {
   @Inject public lateinit var injectedPresenter: P
-  internal var actualPresenter: P? = null
+
+  @CoreFriendModuleApi public var actualPresenter: P? = null
   private val _lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, 0, BufferOverflow.DROP_OLDEST)
   public open val lifecycleFlow: SharedFlow<InteractorEvent>
     get() = _lifecycleFlow
 
   @Volatile private var _lifecycleObservable: Observable<InteractorEvent>? = null
+
+  @OptIn(CoreFriendModuleApi::class)
   private val lifecycleObservable
     get() = ::_lifecycleObservable.setIfNullAndGet { lifecycleFlow.asObservable() }
 
@@ -54,6 +58,7 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
   public open var router: R by routerDelegate
     protected set
 
+  @OptIn(CoreFriendModuleApi::class)
   protected constructor(presenter: P) : this() {
     this.actualPresenter = presenter
   }
@@ -67,6 +72,7 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
 
   final override fun peekLifecycle(): InteractorEvent? = lifecycleFlow.replayCache.lastOrNull()
 
+  @OptIn(CoreFriendModuleApi::class)
   final override fun requestScope(): CompletableSource =
     lifecycleFlow.asScopeCompletable(lifecycleRange)
 
@@ -149,13 +155,15 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
     return getPresenter()
   }
 
-  internal fun setRouterInternal(router: Router<*>) {
+  @CoreFriendModuleApi
+  public fun setRouterInternal(router: Router<*>) {
     if (routerDelegate != null) {
       this.router = router as R
     }
   }
 
   /** @return the currently attached presenter if there is one */
+  @OptIn(CoreFriendModuleApi::class)
   @VisibleForTesting
   private fun getPresenter(): P {
     val presenter: P? =
@@ -172,6 +180,7 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
     return presenter
   }
 
+  @OptIn(CoreFriendModuleApi::class)
   @VisibleForTesting
   internal fun setPresenter(presenter: P) {
     actualPresenter = presenter

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/LazyBackingProperty.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/LazyBackingProperty.kt
@@ -15,6 +15,7 @@
  */
 package com.uber.rib.core
 
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -30,8 +31,9 @@ import kotlin.reflect.KMutableProperty0
  *
  * To properly support concurrency, the backing mutable property should be [Volatile].
  */
-internal inline fun <T : Any> KMutableProperty0<T?>.setIfNullAndGet(
+@CoreFriendModuleApi
+public inline fun <T : Any> KMutableProperty0<T?>.setIfNullAndGet(
   initializer: () -> T,
 ): T = get() ?: synchronized(Lock) { get() ?: initializer().also { set(it) } }
 
-private object Lock
+@CoreFriendModuleApi public object Lock

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Presenter.kt
@@ -17,6 +17,7 @@ package com.uber.rib.core
 
 import androidx.annotation.CallSuper
 import com.uber.autodispose.ScopeProvider
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import com.uber.rib.core.lifecycle.PresenterEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
@@ -39,6 +40,8 @@ public abstract class Presenter : ScopeProvider, RibActionEmitter {
     get() = _lifecycleFlow
 
   @Volatile private var _lifecycleObservable: Observable<PresenterEvent>? = null
+
+  @OptIn(CoreFriendModuleApi::class)
   private val lifecycleObservable
     get() = ::_lifecycleObservable.setIfNullAndGet { lifecycleFlow.asObservable() }
 
@@ -70,6 +73,7 @@ public abstract class Presenter : ScopeProvider, RibActionEmitter {
   /** @return an observable of this controller's lifecycle events. */
   public fun lifecycle(): Observable<PresenterEvent> = lifecycleObservable
 
+  @OptIn(CoreFriendModuleApi::class)
   final override fun requestScope(): CompletableSource =
     lifecycleFlow.asScopeCompletable(lifecycleRange)
 

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
@@ -20,6 +20,7 @@ import androidx.annotation.CallSuper
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import com.uber.rib.core.RibEvents.triggerRibActionAndEmitEvents
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -40,7 +41,8 @@ protected constructor(
     get() = interactor as Interactor<*, *>
 
   /** @return the Tag. */
-  internal var tag: String? = null
+  @CoreFriendModuleApi
+  public var tag: String? = null
     private set
   private var savedInstanceState: Bundle? = null
   private var isLoaded = false
@@ -58,6 +60,7 @@ protected constructor(
     (component as? InteractorBaseComponent<Interactor<*, *>>)?.inject(interactorGeneric)
   }
 
+  @OptIn(CoreFriendModuleApi::class)
   protected open fun attachToInteractor() {
     interactorGeneric.setRouterInternal(this)
   }
@@ -99,6 +102,7 @@ protected constructor(
    * @param childRouter the [Router] to be attached.
    * @param tag an identifier to namespace saved instance state [Bundle] objects.
    */
+  @OptIn(CoreFriendModuleApi::class)
   @MainThread
   public open fun attachChild(childRouter: Router<*>, tag: String) {
     for (child in children) {
@@ -146,6 +150,7 @@ protected constructor(
    *
    * @param childRouter the [Router] to be detached.
    */
+  @OptIn(CoreFriendModuleApi::class)
   @MainThread
   public open fun detachChild(childRouter: Router<*>) {
     val isChildRemoved = children.remove(childRouter)
@@ -185,6 +190,7 @@ protected constructor(
     dispatchAttach(savedInstanceState, javaClass.name)
   }
 
+  @OptIn(CoreFriendModuleApi::class)
   @CallSuper
   @Initializer
   public open fun dispatchAttach(savedInstanceState: Bundle?, tag: String) {
@@ -218,7 +224,8 @@ protected constructor(
    *
    * @return Children.
    */
-  internal open fun getChildren(): List<Router<*>> {
+  @CoreFriendModuleApi
+  public open fun getChildren(): List<Router<*>> {
     return children
   }
 
@@ -226,6 +233,7 @@ protected constructor(
     saveInstanceState(outState)
   }
 
+  @OptIn(CoreFriendModuleApi::class)
   protected open fun saveInstanceState(outState: Bundle) {
     val interactorSavedInstanceState = Bundle()
     interactorGeneric.onSaveInstanceStateInternal(interactorSavedInstanceState)

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -19,6 +19,7 @@ import androidx.annotation.VisibleForTesting
 import com.uber.autodispose.ScopeProvider
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import com.uber.rib.core.RibEvents.triggerRibActionAndEmitEvents
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import com.uber.rib.core.lifecycle.InteractorEvent
 import com.uber.rib.core.lifecycle.PresenterEvent
 import com.uber.rib.core.lifecycle.WorkerEvent
@@ -157,6 +158,7 @@ public object WorkerBinder {
     }
   }
 
+  @OptIn(CoreFriendModuleApi::class)
   @JvmStatic
   @VisibleForTesting
   @Deprecated(
@@ -226,6 +228,7 @@ public object WorkerBinder {
    * @param workerLifecycle the worker lifecycle event provider
    * @param worker the class that wants to be informed when to start and stop doing work
    */
+  @OptIn(CoreFriendModuleApi::class)
   @JvmStatic
   @Deprecated(
     message =

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerScopeProvider.kt
@@ -16,6 +16,7 @@
 package com.uber.rib.core
 
 import com.uber.autodispose.ScopeProvider
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.CompletableSource
 import io.reactivex.Observable
@@ -23,7 +24,8 @@ import io.reactivex.Observable
 /** [ScopeProvider] for [Worker] instances. */
 public open class WorkerScopeProvider internal constructor(delegate: ScopeProvider) :
   ScopeProvider by delegate {
-  internal constructor(lifecycle: Observable<WorkerEvent>) : this(lifecycle.asScopeProvider())
+  @CoreFriendModuleApi
+  public constructor(lifecycle: Observable<WorkerEvent>) : this(lifecycle.asScopeProvider())
 }
 
 private fun Observable<*>.asScopeProvider() = asCompletableSource().asScopeProvider()

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/internal/CoreFriendModuleApi.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/internal/CoreFriendModuleApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2023. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.uber.rib.core.internal
 
-plugins {
-    id("ribs.kotlin-library-conventions")
-    alias(libs.plugins.mavenPublish)
-}
-
-kotlin {
-    explicitApi()
-    jvmToolchain(8)
-}
-
-dependencies {
-    implementation(project(":libraries:rib-base"))
-}
+/*
+ * Methods that are visible only to rib-base friend modules.
+ *
+ * Anything marked with this annotation is not intended for public use.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR) internal annotation class CoreFriendModuleApi

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/LazyBackingPropertyTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/LazyBackingPropertyTest.kt
@@ -16,6 +16,7 @@
 package com.uber.rib.core
 
 import com.google.common.truth.Truth.assertThat
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import io.reactivex.Observable
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.channels.toList
@@ -26,6 +27,8 @@ import org.mockito.kotlin.mock
 
 class LazyBackingPropertyTest {
   @Volatile private var _expensiveObject: ExpensiveObject? = null
+
+  @OptIn(CoreFriendModuleApi::class)
   private val expensiveObject
     get() = ::_expensiveObject.setIfNullAndGet { ExpensiveObject() }
 
@@ -47,6 +50,8 @@ class LazyBackingPropertyTest {
 
 private open class ClassToBeMocked {
   @Volatile private var _prop: Observable<Int>? = null
+
+  @OptIn(CoreFriendModuleApi::class)
   val prop: Observable<Int>
     get() = ::_prop.setIfNullAndGet { Observable.just(1, 2, 3) }
 }

--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerScopeProviderTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/WorkerScopeProviderTest.kt
@@ -17,6 +17,7 @@ package com.uber.rib.core
 
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
+import com.uber.rib.core.internal.CoreFriendModuleApi
 import com.uber.rib.core.lifecycle.WorkerEvent
 import io.reactivex.observers.TestObserver
 import org.junit.Before
@@ -27,6 +28,7 @@ class WorkerScopeProviderTest {
   private val lifecycle: Relay<WorkerEvent> = BehaviorRelay.create()
   private lateinit var testObserver: TestObserver<Any>
 
+  @OptIn(CoreFriendModuleApi::class)
   @Before
   fun setUp() {
     testObserver = TestObserver()

--- a/android/libraries/rib-coroutines-test/build.gradle.kts
+++ b/android/libraries/rib-coroutines-test/build.gradle.kts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("ribs.kotlin-library-conventions")
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    sourceSets {
+        configureEach {
+            languageSettings {
+                optIn("com.uber.rib.core.internal.CoroutinesFriendModuleApi")
+            }
+        }
+    }
+}
+
+dependencies {
+    api(project(":libraries:rib-coroutines"))
+    api(testLibs.coroutines.test)
+    api(testLibs.junit)
+
+    compileOnly(libs.android.api)
+
+    testImplementation(project(":libraries:rib-base"))
+    testImplementation(project(":libraries:rib-test"))
+    testImplementation(testLibs.junit)
+    testImplementation(testLibs.mockito)
+    testImplementation(testLibs.mockitoKotlin)
+    testImplementation(testLibs.truth)
+    testImplementation(testLibs.coroutines.test)
+    testImplementation(libs.coroutines.android)
+    testImplementation(libs.annotation)
+    testImplementation(libs.android.api)
+}

--- a/android/libraries/rib-coroutines-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineScopes.kt
+++ b/android/libraries/rib-coroutines-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineScopes.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.core
 
 import android.app.Application

--- a/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutineScopes.kt
+++ b/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutineScopes.kt
@@ -18,6 +18,7 @@ package com.uber.rib.core
 import android.app.Application
 import com.uber.autodispose.ScopeProvider
 import com.uber.autodispose.coroutinesinterop.asCoroutineScope
+import com.uber.rib.core.internal.CoroutinesFriendModuleApi
 import java.util.WeakHashMap
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -34,6 +35,7 @@ import kotlinx.coroutines.job
  * This scope is bound to
  * [RibDispatchers.Main.immediate][kotlinx.coroutines.MainCoroutineDispatcher.immediate]
  */
+@OptIn(CoroutinesFriendModuleApi::class)
 public val ScopeProvider.coroutineScope: CoroutineScope by
   LazyCoroutineScope<ScopeProvider> {
     val context: CoroutineContext =
@@ -52,6 +54,7 @@ public val ScopeProvider.coroutineScope: CoroutineScope by
  * This scope is bound to
  * [RibDispatchers.Main.immediate][kotlinx.coroutines.MainCoroutineDispatcher.immediate]
  */
+@OptIn(CoroutinesFriendModuleApi::class)
 public val Application.coroutineScope: CoroutineScope by
   LazyCoroutineScope<Application> {
     val context: CoroutineContext =
@@ -63,17 +66,18 @@ public val Application.coroutineScope: CoroutineScope by
     CoroutineScope(context)
   }
 
-internal class LazyCoroutineScope<This : Any>(val initializer: This.() -> CoroutineScope) {
-  companion object {
+@CoroutinesFriendModuleApi
+public class LazyCoroutineScope<This : Any>(private val initializer: This.() -> CoroutineScope) {
+  public companion object {
     private val values = WeakHashMap<Any, CoroutineScope>()
 
     // Used to get and set Test overrides from rib-coroutines-test utils
-    operator fun get(provider: Any) = values[provider]
-    operator fun set(provider: Any, scope: CoroutineScope?) {
+    public operator fun get(provider: Any): CoroutineScope? = values[provider]
+    public operator fun set(provider: Any, scope: CoroutineScope?) {
       values[provider] = scope
     }
   }
-  operator fun getValue(thisRef: This, property: KProperty<*>): CoroutineScope =
+  public operator fun getValue(thisRef: This, property: KProperty<*>): CoroutineScope =
     synchronized(LazyCoroutineScope) {
       return values.getOrPut(thisRef) {
         thisRef.initializer().apply {

--- a/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/internal/CoroutinesFriendModuleApi.kt
+++ b/android/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/internal/CoroutinesFriendModuleApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2023. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.uber.rib.core
+package com.uber.rib.core.internal
 
-import com.uber.rib.core.lifecycle.WorkerEvent
-import io.reactivex.Observable
-
-/** Helper to unit test [Worker] instances. */
-public object WorkerHelper {
-  /**
-   * Creates a [WorkerScopeProvider] that can be driven by a test observable.
-   *
-   * @param lifecycle to wrap.
-   * @return a [WorkerScopeProvider].
-   */
-  @JvmStatic
-  public fun createScopeProvider(lifecycle: Observable<WorkerEvent>): WorkerScopeProvider {
-    return WorkerScopeProvider(lifecycle)
-  }
-}
+/*
+ * Methods that are visible only to rib-coroutines friend modules.
+ *
+ * Anything marked with this annotation is not intended for public use.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+internal annotation class CoroutinesFriendModuleApi

--- a/android/libraries/rib-debug-utils/build.gradle.kts
+++ b/android/libraries/rib-debug-utils/build.gradle.kts
@@ -13,26 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 plugins {
-    id("ribs.kotlin-android-library-conventions")
+    id("ribs.kotlin-library-conventions")
     alias(libs.plugins.mavenPublish)
 }
 
-android {
-    namespace "com.uber.rib.workflow.test"
-
-    // This module is only testing utilities. Given this code isn't intended to be run inside a production
-    // android app this module confuses android lint. Let's just disable lint errors here.
-    lint {
-        abortOnError false
-        disable 'InvalidPackage'
+kotlin {
+    sourceSets {
+        configureEach {
+            languageSettings {
+                optIn("com.uber.rib.core.internal.CoreFriendModuleApi")
+            }
+        }
     }
+    explicitApi()
+    jvmToolchain(8)
 }
 
 dependencies {
-    api(project(":libraries:rib-workflow"))
-    api(libs.guava.android)
-    api(libs.rxjava2)
-    implementation(libs.annotation)
-    implementation(testLibs.truth)
+    implementation(project(":libraries:rib-base"))
 }

--- a/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
+++ b/android/libraries/rib-debug-utils/src/main/kotlin/com/uber/rib/core/RouterDebugUtils.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.core
 
 /** Debugging utilities when working with Routers. */

--- a/android/libraries/rib-test/build.gradle.kts
+++ b/android/libraries/rib-test/build.gradle.kts
@@ -19,22 +19,22 @@ plugins {
     alias(libs.plugins.mavenPublish)
 }
 
+kotlin {
+    sourceSets {
+        configureEach {
+            languageSettings {
+                optIn("com.uber.rib.core.internal.CoreFriendModuleApi")
+            }
+        }
+    }
+}
+
 dependencies {
-    api(project(':libraries:rib-coroutines'))
-    api(testLibs.coroutines.test)
+    api(project(":libraries:rib-base"))
+    implementation(libs.rxjava2)
+    implementation(libs.kotlin.stdlib)
     api(testLibs.junit)
-
-    compileOnly(libs.android.api)
-
-    testImplementation(project(":libraries:rib-base"))
-    testImplementation(project(":libraries:rib-test"))
-    testImplementation(testLibs.junit)
-    testImplementation(testLibs.mockito)
-    testImplementation(testLibs.mockitoKotlin)
-    testImplementation(testLibs.truth)
-    testImplementation(testLibs.coroutines.test)
-    testImplementation(libs.coroutines.android)
-    testImplementation(libs.annotation)
-    testImplementation(libs.android.api)
-
+    api(testLibs.truth)
+    api(testLibs.mockito)
+    implementation(testLibs.mockitoKotlin)
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/FakeInteractor.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.core
 
 @SuppressWarnings("RibInteractorOnIteractor")

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/InteractorHelper.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.core
 
 import org.mockito.AdditionalMatchers.or

--- a/android/libraries/rib-workflow-test/build.gradle.kts
+++ b/android/libraries/rib-workflow-test/build.gradle.kts
@@ -19,25 +19,30 @@ plugins {
 }
 
 android {
-    namespace "com.uber.rib.android"
+    namespace = "com.uber.rib.workflow.test"
+
+    // This module is only testing utilities. Given this code isn't intended to be run inside a production
+    // android app this module confuses android lint. Let's just disable lint errors here.
+    lint {
+        abortOnError = false
+        disable.add("InvalidPackage")
+    }
+}
+
+kotlin {
+    sourceSets {
+        configureEach {
+            languageSettings {
+                optIn("com.uber.rib.workflow.core.internal.WorkflowFriendModuleApi")
+            }
+        }
+    }
 }
 
 dependencies {
-    api(project(":libraries:rib-android-core"))
-    api(project(":libraries:rib-base"))
-    api(libs.rxkotlin)
-    api(libs.rxrelay2)
+    api(project(":libraries:rib-workflow"))
+    api(libs.guava.android)
     api(libs.rxjava2)
-    implementation(libs.javax.inject)
     implementation(libs.annotation)
-    implementation(libs.appcompat)
-    implementation(libs.guava.android)
-    implementation(libs.autodispose.coroutines)
-    implementation(libs.coroutines.android)
-    implementation(libs.coroutines.rx2)
-    testImplementation(testLibs.robolectric)
-    testImplementation(libs.lifecycle.runtime)
-    testImplementation(libs.appcompat)
-    testImplementation(testLibs.mockitoKotlin)
-    testImplementation(project(":libraries:rib-test"))
+    implementation(testLibs.truth)
 }

--- a/android/libraries/rib-workflow-test/src/main/kotlin/com/uber/rib/workflow/core/StepTester.kt
+++ b/android/libraries/rib-workflow-test/src/main/kotlin/com/uber/rib/workflow/core/StepTester.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("invisible_reference", "invisible_member")
-
 package com.uber.rib.workflow.core
 
 import com.google.common.base.Optional
@@ -23,7 +21,7 @@ import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 
 /** Utility to expose [Observable] instances on a [Step] for unit testing purposes. */
-object StepTester {
+public object StepTester {
   /**
    * Exposes a [Step] instances observable for testing purposes.
    *
@@ -33,7 +31,7 @@ object StepTester {
    * @return a [Observable] that runs the steps action. </A></T>
    */
   @JvmStatic
-  fun <T, A : ActionableItem> exposeObservable(
+  public fun <T, A : ActionableItem> exposeObservable(
     step: Step<T, A>,
   ): Observable<Optional<Step.Data<T, A>>> {
     return step.asObservable()
@@ -48,7 +46,7 @@ object StepTester {
    * @return the data of the step </A></T>
    */
   @JvmStatic
-  fun <T, A : ActionableItem> exposeStepData(step: Step.Data<T, A>): T? {
+  public fun <T, A : ActionableItem> exposeStepData(step: Step.Data<T, A>): T? {
     return step.getValue()
   }
 
@@ -60,7 +58,7 @@ object StepTester {
    * @param <A> type of next actionable item for a step. </A></T>
    */
   @JvmStatic
-  fun <T, A : ActionableItem> assertStepNotYetEmitted(
+  public fun <T, A : ActionableItem> assertStepNotYetEmitted(
     testSubscriber: TestObserver<Optional<Step.Data<T, A>>>,
   ) {
     testSubscriber.run {
@@ -78,7 +76,7 @@ object StepTester {
    * @param <A> type of next actionable item for a step. </A></T>
    */
   @JvmStatic
-  fun <T, A : ActionableItem> assertStepEmitted(
+  public fun <T, A : ActionableItem> assertStepEmitted(
     testSubscriber: TestObserver<Optional<Step.Data<T, A>>>,
   ) {
     testSubscriber.assertValueCount(1)

--- a/android/libraries/rib-workflow/src/main/kotlin/com/uber/rib/workflow/core/Step.kt
+++ b/android/libraries/rib-workflow/src/main/kotlin/com/uber/rib/workflow/core/Step.kt
@@ -17,6 +17,7 @@ package com.uber.rib.workflow.core
 
 import com.google.common.base.Optional
 import com.uber.rib.core.lifecycle.InteractorEvent
+import com.uber.rib.workflow.core.internal.WorkflowFriendModuleApi
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -44,8 +45,11 @@ private constructor(
    * @param <A2> the actionable item type returned by the next step.
    * @return a [Step] to chain more calls to.
    */
+  @OptIn(WorkflowFriendModuleApi::class)
   @SuppressWarnings("RxJavaToSingle") // Replace singleOrError() with firstOrError()
-  open fun <T2, A2 : ActionableItem> onStep(func: BiFunction<T, A, Step<T2, A2>>): Step<T2, A2> {
+  public open fun <T2, A2 : ActionableItem> onStep(
+    func: BiFunction<T, A, Step<T2, A2>>,
+  ): Step<T2, A2> {
     return Step(
       asObservable()
         .flatMap { data: Optional<Data<T, A>> ->
@@ -59,11 +63,13 @@ private constructor(
     )
   }
 
+  @OptIn(WorkflowFriendModuleApi::class)
   internal open fun asResultObservable(): Observable<Optional<T>> {
     return asObservable().map { data -> Optional.fromNullable(data.orNull()?.getValue()) }
   }
 
-  internal open fun asObservable(): Observable<Optional<Data<T, A>>> {
+  @WorkflowFriendModuleApi
+  public open fun asObservable(): Observable<Optional<Data<T, A>>> {
     val cachedObservable: Observable<Optional<Data<T, A>>> =
       stepDataSingle.toObservable().observeOn(AndroidSchedulers.mainThread()).cache()
     return cachedObservable.flatMap { dataOptional: Optional<Data<T, A>> ->
@@ -88,9 +94,12 @@ private constructor(
    * @param value for this instance.
    * @param actionableItem for this instance.
    */
-  open class Data<T, A : ActionableItem>(private val value: T, internal val actionableItem: A) {
+  public open class Data<T, A : ActionableItem>(
+    private val value: T,
+    internal val actionableItem: A,
+  ) {
 
-    internal open fun getValue() = value
+    @WorkflowFriendModuleApi public open fun getValue() = value
 
     companion object {
       /**
@@ -102,7 +111,7 @@ private constructor(
        * @return a new [Step.Data] instance. </A>
        */
       @JvmStatic
-      fun <A : ActionableItem> toActionableItem(actionableItem: A): Data<NoValue, A> {
+      public fun <A : ActionableItem> toActionableItem(actionableItem: A): Data<NoValue, A> {
         return Data(NoValueHolder.INSTANCE, actionableItem)
       }
     }

--- a/android/libraries/rib-workflow/src/main/kotlin/com/uber/rib/workflow/core/internal/WorkflowFriendModuleApi.kt
+++ b/android/libraries/rib-workflow/src/main/kotlin/com/uber/rib/workflow/core/internal/WorkflowFriendModuleApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2023. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.uber.rib.workflow.core.internal
 
-plugins {
-    id("ribs.kotlin-library-conventions")
-    alias(libs.plugins.mavenPublish)
-}
-
-dependencies {
-    api(project(":libraries:rib-base"))
-    implementation(libs.rxjava2)
-    implementation(libs.kotlin.stdlib)
-    api(testLibs.junit)
-    api(testLibs.truth)
-    api(testLibs.mockito)
-    implementation(testLibs.mockitoKotlin)
-}
+/*
+ * Methods that are visible only to rib-workflow friend modules.
+ *
+ * Anything marked with this annotation is not intended for public use.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR) internal annotation class WorkflowFriendModuleApi

--- a/android/libraries/rib-workflow/src/test/kotlin/com/uber/rib/workflow/core/StepTest.kt
+++ b/android/libraries/rib-workflow/src/test/kotlin/com/uber/rib/workflow/core/StepTest.kt
@@ -19,6 +19,7 @@ import com.google.common.base.Optional
 import com.google.common.truth.Truth.assertThat
 import com.uber.rib.core.lifecycle.InteractorEvent
 import com.uber.rib.workflow.core.Step.Data
+import com.uber.rib.workflow.core.internal.WorkflowFriendModuleApi
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.BehaviorSubject
@@ -27,6 +28,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(WorkflowFriendModuleApi::class)
 class StepTest {
 
   @get:Rule var androidSchedulersRuleRx2 = AndroidSchedulersRule()


### PR DESCRIPTION
For accessing internal declarations from "friend" modules (e.g. access `rib-base` internals from `rib-test`), we are currently suppressing compiler errors with `@file:Suppress("invisible_reference", "invisible_member")`

A better approach is to:
1. Create an `internal` opt-in annotation.
2. Make the "accessible to friend modules" component `public`
3. Mark the (now public) component with the opt-in annotation.
4. Opt-in to the annotation from `build.gradle`.

Because the new annotation is `internal`, it cannot be normally accessed from external modules. But Gradle can see it if it's part of the source set.

Benefits:
1. We get rid of the hacky suppressions in our codebase.
2. By suppressing `invisible_reference` and `invisible_member` we gain access to *all* internal components from the other modules, and that's not ideal: we'd rather be explicit about what are the APIs that are visible for module friends, and what are truly internal for the module and should never be used even from module friends.
3. We make the internal visibility of those friend-modules APIs even stricter, since consumers from the general public now cannot just suppress `"invisible_reference"` and `"invisible_member"` to directly access the friend-module API -- they require explicit Opt-In. They would need to suppress invisible members AND opt-in. 
