### PR TITLE
Introduce `TestScope.test(RibCoroutineWorker)` test helper utility.

### DIFF
--- a/android/libraries/rib-test/build.gradle.kts
+++ b/android/libraries/rib-test/build.gradle.kts
@@ -36,5 +36,6 @@ dependencies {
     api(testLibs.junit)
     api(testLibs.truth)
     api(testLibs.mockito)
+    api(testLibs.coroutines.test)
     implementation(testLibs.mockitoKotlin)
 }

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineWorker.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineWorker.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+
+/**
+ * Binds [worker], runs [testBody] with the worker, and unbinds worker after [testBody] returns.
+ *
+ * This function calls [runCurrent] on the [TestScope] immediately after binding the [worker]. This
+ * means that if, and only if, there's no delay in [RibCoroutineWorker.onStart] function, worker
+ * will already be bound at the start of [testBody] lambda. If there are delays, calling
+ * [advanceTimeBy] or [advanceUntilIdle] at the start of [testBody] is needed to complete the
+ * binding.
+ *
+ * The same rationale applies for coroutines launched in the [CoroutineScope] parameter of
+ * [RibCoroutineWorker.onStart]: if there are no delays involved, coroutines will be run until idle
+ * or completed, otherwise, the aforementioned time advancing API must be used.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+public inline fun <T : RibCoroutineWorker> TestScope.test(
+  worker: T,
+  crossinline testBody: TestScope.(T) -> Unit,
+) {
+  val dispatcher = StandardTestDispatcher(testScheduler)
+  val handle = bind(worker, dispatcher)
+  runCurrent()
+  try {
+    testBody(worker)
+  } finally {
+    handle.unbind()
+    runCurrent()
+  }
+}


### PR DESCRIPTION
This helper utility is meant to be used in tests inside `runTest { }` blocks and should facilitate `RibCoroutineWorker` testing by automatically binding and unbinding the worker.

1. A test dispatcher is used to bind the worker (`StandardTestDispatcher`), so the test shall work even when `RibCoroutinesRule` is not used to override the `RibDispatchers.Default` dispatcher with a test dispatcher.
2. Worker is only bound in the scope of the lambda passed to `test(RibCoroutineWorker)`, hence tests never timeout with uncompleted coroutines because of a bound worker.

```
@Test fun test() = runTest {
  test(worker) {
    // Worker is bound. Make assertions
  }
  // Worker is unbound.
}
```

