### PR TITLE
Refactor internal methods to avoid duplicate JVM signature

### DIFF
--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -104,7 +104,7 @@ public abstract class RibActivity :
   override fun onSaveInstanceState(outState: android.os.Bundle) {
     super.onSaveInstanceState(outState)
     _callbacksFlow.tryEmit(createOnSaveInstanceStateEvent(outState))
-    router?.dispatchSaveInstanceState(Bundle(outState))
+    router?.saveInstanceStateInternal(Bundle(outState))
       ?: throw NullPointerException("Router should not be null")
   }
 

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/RibActivity.kt
@@ -104,7 +104,7 @@ public abstract class RibActivity :
   override fun onSaveInstanceState(outState: android.os.Bundle) {
     super.onSaveInstanceState(outState)
     _callbacksFlow.tryEmit(createOnSaveInstanceStateEvent(outState))
-    router?.saveInstanceStateInternal(Bundle(outState))
+    router?.dispatchSaveInstanceState(Bundle(outState))
       ?: throw NullPointerException("Router should not be null")
   }
 

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
@@ -48,7 +48,7 @@ abstract class ViewRouter<V : View, I : Interactor<*, *>> : Router<I> {
     }
   }
 
-  internal fun saveInstanceStateInternal(outState: Bundle) {
+  internal fun dispatchSaveInstanceState(outState: Bundle) {
     saveInstanceState(outState)
   }
 }

--- a/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
+++ b/android/libraries/rib-android/src/main/kotlin/com/uber/rib/core/ViewRouter.kt
@@ -47,8 +47,4 @@ abstract class ViewRouter<V : View, I : Interactor<*, *>> : Router<I> {
       XRay.apply(this, view)
     }
   }
-
-  internal fun dispatchSaveInstanceState(outState: Bundle) {
-    saveInstanceState(outState)
-  }
 }

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Router.kt
@@ -229,7 +229,8 @@ protected constructor(
     return children
   }
 
-  internal fun saveInstanceStateInternal(outState: Bundle) {
+  @CoreFriendModuleApi
+  public fun saveInstanceStateInternal(outState: Bundle) {
     saveInstanceState(outState)
   }
 


### PR DESCRIPTION
`ViewRouter` extends from `Router` & both have a method: `internal fun onSaveInstanceStateInternal(outState: Bundle)`.
In order to avoid exposing this method to non-RIB-class subclasses, the method was duplicated each Router class w/ internal visibility. But, starting in K2 this fails with duplicate JVM signature, so this PR removes the `ViewRouter` copy & makes the `Router` copy public but requiring a core annotation.
