### PR TITLE
Make suspend functions callable inside `test(worker) { }`

### DIFF
--- a/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
+++ b/android/libraries/rib-base/src/test/kotlin/com/uber/rib/core/RibCoroutineWorkerTest.kt
@@ -190,6 +190,8 @@ class RibCoroutineWorkerTest {
     assertThat(worker.innerCoroutineCompleted).isFalse()
     assertThat(worker.onStopRan).isFalse()
     test(worker) {
+      // Quick check that suspend functions can be called inside this block
+      delay(0)
       // Assert onStart and inner coroutine started but have not finished (it has delays)
       assertThat(it.onStartStarted).isTrue()
       assertThat(it.innerCoroutineStarted).isTrue()

--- a/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineWorker.kt
+++ b/android/libraries/rib-test/src/main/kotlin/com/uber/rib/core/TestRibCoroutineWorker.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.test.runCurrent
 @OptIn(ExperimentalCoroutinesApi::class)
 public inline fun <T : RibCoroutineWorker> TestScope.test(
   worker: T,
-  crossinline testBody: TestScope.(T) -> Unit,
+  testBody: TestScope.(T) -> Unit,
 ) {
   val dispatcher = StandardTestDispatcher(testScheduler)
   val handle = bind(worker, dispatcher)


### PR DESCRIPTION
We don't need `crossinline` for `testBody`. Usage of cross-inline makes suspend functions non-callable in the test body, which forbids patterns like:
```
test(worker) {
  sharedFlow.emit(someValue)
  // assert worker processed it
}
```