### PR TITLE
`ScopeProvider.coroutineScope`: Fail silently when accessing outside of RIB scope.

### DIFF
--- a/libraries/rib-coroutines/build.gradle.kts
+++ b/libraries/rib-coroutines/build.gradle.kts
@@ -13,22 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
     id("ribs.kotlin.library")
     alias(libs.plugins.maven.publish)
 }
 
 dependencies {
-
     api(libs.autodispose.coroutines)
     api(libs.kotlinx.coroutines.android)
     api(libs.kotlinx.coroutines.rx2)
 
     compileOnly(libs.android.api)
 
+    implementation(libs.autodispose.lifecycle)
+
     testImplementation(project(":libraries:rib-base"))
     testImplementation(project(":libraries:rib-test"))
+    testImplementation(project(":libraries:rib-coroutines-test"))
     testImplementation(testLibs.junit)
     testImplementation(testLibs.mockito)
     testImplementation(testLibs.mockito.kotlin)

--- a/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutinesConfig.kt
+++ b/libraries/rib-coroutines/src/main/kotlin/com/uber/rib/core/RibCoroutinesConfig.kt
@@ -39,6 +39,14 @@ public object RibCoroutinesConfig {
   @JvmStatic public var exceptionHandler: CoroutineExceptionHandler? = null
 
   /**
+   * When set, the `coroutineScope` extension property will fail silently (i.e. not throw) when
+   * accessed after the scope has completed.
+   *
+   * Defaults to `false`.
+   */
+  @JvmStatic public var shouldCoroutineScopeFailSilentlyOnLifecycleEnded: Boolean = false
+
+  /**
    * Specify the [CoroutineDispatcher] to be used while binding a [com.uber.rib.Worker] via
    * [WorkerBinder]
    *

--- a/libraries/rib-coroutines/src/test/kotlin/com/uber/rib/core/RibCoroutineScopesTest.kt
+++ b/libraries/rib-coroutines/src/test/kotlin/com/uber/rib/core/RibCoroutineScopesTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rib.core
+
+import com.google.common.truth.Truth.assertThat
+import com.uber.autodispose.lifecycle.LifecycleEndedException
+import com.uber.autodispose.lifecycle.LifecycleNotStartedException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(Parameterized::class)
+class RibCoroutineScopesTest(private val failSilentlyOnLifecycleEnded: Boolean) {
+  @get:Rule val ribCoroutinesRule = RibCoroutinesRule()
+  private val interactor = TestInteractor()
+
+  @Before
+  fun setUp() {
+    RibCoroutinesConfig.shouldCoroutineScopeFailSilentlyOnLifecycleEnded =
+      failSilentlyOnLifecycleEnded
+  }
+
+  @Test
+  fun coroutineScope_whenCalledBeforeActive_throws() {
+    assertThrows(LifecycleNotStartedException::class.java) { interactor.coroutineScope }
+  }
+
+  @Test
+  fun coroutineScope_whenCalledAfterInactive_throws() {
+    interactor.attachAndDetach {}
+    if (failSilentlyOnLifecycleEnded) {
+      assertThat(interactor.coroutineScope.isActive).isFalse()
+    } else {
+      assertThrows(LifecycleEndedException::class.java) { interactor.coroutineScope }
+    }
+  }
+
+  @Test
+  fun coroutineScope_whenCalledWhileActive_cancelsWhenInactive() = runTest {
+    var launched = false
+    val job: Job
+    interactor.attachAndDetach {
+      job =
+        coroutineScope.launch {
+          launched = true
+          awaitCancellation()
+        }
+      runCurrent()
+      assertThat(launched).isTrue()
+      assertThat(job.isActive).isTrue()
+    }
+    assertThat(job.isCancelled).isTrue()
+  }
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "failSilentlyOnLifecycleEnded = {0}")
+    fun data() = listOf(arrayOf(true), arrayOf(false))
+  }
+}
+
+private class TestInteractor : Interactor<Unit, Router<*>>()
+
+@OptIn(ExperimentalContracts::class)
+private inline fun TestInteractor.attachAndDetach(block: TestInteractor.() -> Unit) {
+  contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+  InteractorHelper.attach(this, Unit, mock(), null)
+  block()
+  InteractorHelper.detach(this)
+}


### PR DESCRIPTION
Change `ScopeProvider.coroutineScope` throwing behavior when accessing after scope is inactive.

When `RibCoroutinesConfig.shouldCoroutineScopeFailSilentlyOnLifecycleEnded` is enabled, attempting to get an instance of `coroutineScope` after the RIB gets detached will fail silently instead of throwing an error.

Accessing it before RIB is active still throws an exception.

## Motivation

Suppose you have an interactor that starts subscribing to an Rx stream asynchronously.

```kotlin
class MyInteractor {
  override fun didBecomeActive() {
    runLater {
      someObservable.autoDispose(coroutineScope).subscribe()
    }
  }
}
```

It is possible that this Rx subscription will be triggered after interactor's already inactive. In that case, subscription will be No-Op.

This code is incorrect: `Interactor` is attempting to do work after it's inactive. In other words, `runLater` does not respect the interactor lifecycle. Still, considering this is some legacy code being migrated from Rx to Coroutines, the new code would look like the following.

```kotlin
class MyInteractor {
  override fun didBecomeActive() {
    runLater {
      someObservable.autoDispose(coroutineScope).subscribe()
    }
  }
}
```

Unlike the Rx counterpart, this code will sometimes fatally throw. If `ScopeProvider.coroutineScope` is called after the scope's inactive, it will throw `LifecycleEndedException` at call site.

Calling `coroutineScope` outside of lifecycle bounds is incorrect, but in order to allow for a smoother Rx migration to Coroutines, we are changing current implementation to deliver the exception to the `CoroutineExceptionHandler` instead of throwing at call site.

If some app decides to override the default behavior of crashing (in JVM/Android) in face of attempts to obtain coroutineScope when lifecycle is not active, one can customize `RibCoroutinesConfig.exceptionHandler` at app startup:

```kotlin
RibCoroutinesConfig.exceptionHandler = CoroutineExceptionHandler { _, throwable ->
  when (throwable) {
    is CoroutineScopeLifecycleException -> log(throwable) // only log, don't re-throw.
    else -> throw throwable
  }
}
```