### PR TITLE
increase interactor lifecycleFlow buffer size

### DIFF
--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -28,6 +28,7 @@ import javax.inject.Inject
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.rx2.asObservable
@@ -42,7 +43,7 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
   @Inject public lateinit var injectedPresenter: P
 
   @CoreFriendModuleApi public var actualPresenter: P? = null
-  private val _lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, 0, BufferOverflow.DROP_OLDEST)
+  private val _lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, Channel.UNLIMITED, BufferOverflow.DROP_OLDEST)
   public open val lifecycleFlow: SharedFlow<InteractorEvent>
     get() = _lifecycleFlow
 

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/Interactor.kt
@@ -43,7 +43,8 @@ public abstract class Interactor<P : Any, R : Router<*>>() : InteractorType, Rib
   @Inject public lateinit var injectedPresenter: P
 
   @CoreFriendModuleApi public var actualPresenter: P? = null
-  private val _lifecycleFlow = MutableSharedFlow<InteractorEvent>(1, Channel.UNLIMITED, BufferOverflow.DROP_OLDEST)
+  private val _lifecycleFlow =
+    MutableSharedFlow<InteractorEvent>(1, Channel.UNLIMITED, BufferOverflow.DROP_OLDEST)
   public open val lifecycleFlow: SharedFlow<InteractorEvent>
     get() = _lifecycleFlow
 


### PR DESCRIPTION
This increases the lifecycle flow buffer size in the interactor. The existing size drops emissions when there are too many subscribers. The change to the unlimited buffer will maximize the chance of successful emissions.