### PR TITLE
fix IntelliJ arbitrary file access during archive extraction

### DIFF
--- a/tooling/rib-intellij-plugin/src/main/java/com/uber/presidio/intellij_plugin/generator/Generator.java
+++ b/tooling/rib-intellij-plugin/src/main/java/com/uber/presidio/intellij_plugin/generator/Generator.java
@@ -189,6 +189,11 @@ public abstract class Generator {
         String name = entries.nextElement().getName();
         if (name.startsWith(path)) { // filter according to the path
           String entry = name.substring(path.length());
+          java.nio.file.Path normalizedPath = new File(entry).toPath().normalize();
+          java.nio.file.Path basePath = new File(path).toPath().normalize();
+          if (!normalizedPath.startsWith(basePath)) {
+            throw new IOException("Invalid JAR entry: " + name);
+          }
           int checkSubdir = entry.indexOf("/");
           if (checkSubdir >= 0) {
             // if it is a subdirectory, we just return the directory name


### PR DESCRIPTION
https://github.com/uber/RIBs/blob/4a9bbbc9f4433b6bd83ebf7de876105d7f9fed35/tooling/rib-intellij-plugin/src/main/java/com/uber/presidio/intellij_plugin/generator/Generator.java#L189-L189

fix the `rib-intellij-plugin` need to validate the paths extracted from the JAR file to ensure they do not lead to directory traversal vulnerabilities. This involves normalizing the paths and verifying that they remain within the intended directory. 
1. Use `java.nio.file.Path` to normalize the paths extracted from the JAR file.
2. Check that the normalized paths start with the intended base directory using `Path.startsWith(..)`.
3. Reject any paths that fail the validation by throwing an exception or skipping them.

The changes will be applied to the `getResourceListing` method in the file `tooling/rib-intellij-plugin/src/main/java/com/uber/presidio/intellij_plugin/generator/Generator.java`.


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

