### PR TITLE
Replace the SharedFlow with a StateFlow in the Interactor class

### DIFF
--- a/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
+++ b/libraries/rib-base/src/main/kotlin/com/uber/rib/core/FlowAsScope.kt
@@ -38,17 +38,17 @@ import kotlinx.coroutines.rx2.rxCompletable
  *    [range].
  */
 @CoreFriendModuleApi
-public fun <T : Comparable<T>> SharedFlow<T>.asScopeCompletable(
+public fun <T : Comparable<T>> SharedFlow<T?>.asScopeCompletable(
   range: ClosedRange<T>,
   context: CoroutineContext = EmptyCoroutineContext,
 ): CompletableSource {
   ensureAlive(range)
   return rxCompletable(RibDispatchers.Unconfined + context) {
-    takeWhile { it < range.endInclusive }.collect()
+    takeWhile { it == null || it < range.endInclusive }.collect()
   }
 }
 
-private fun <T : Comparable<T>> SharedFlow<T>.ensureAlive(range: ClosedRange<T>) {
+private fun <T : Comparable<T>> SharedFlow<T?>.ensureAlive(range: ClosedRange<T>) {
   val lastEmitted = replayCache.lastOrNull()
   when {
     lastEmitted == null || lastEmitted < range.start -> throw LifecycleNotStartedException()

--- a/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
+++ b/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RibEvents.kt
@@ -35,6 +35,9 @@ public object RibEvents {
   @JvmStatic
   public val ribActionEvents: Observable<RibActionInfo> = mutableRibDurationEvents.asObservable()
 
+  internal var useStateFlowInteractorEvent: Boolean = false
+    private set
+
   /** Indicates if [ribActionEvents] will be emitting. */
   public var areRibActionEmissionsAllowed: Boolean = false
     @VisibleForTesting internal set
@@ -46,6 +49,12 @@ public object RibEvents {
   @JvmStatic
   public fun enableRibActionEmissions() {
     this.areRibActionEmissionsAllowed = true
+  }
+
+  /** If true, the [Interactor] will use [MutableStateFlow] for the interactor events. */
+  @JvmStatic
+  public fun useStateFlowInteractorEvent() {
+    this.useStateFlowInteractorEvent = true
   }
 
   /**

--- a/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
+++ b/libraries/rib-base/src/main/kotlin/com/uber/rib/core/WorkerBinder.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
@@ -264,7 +264,7 @@ private fun getJobCoroutineContext(
 }
 
 private fun <T : Comparable<T>> Worker.bind(
-  lifecycle: SharedFlow<T>,
+  lifecycle: Flow<T>,
   lifecycleRange: ClosedRange<T>,
 ): WorkerUnbinder {
   val dispatcherAtBinder = RibCoroutinesConfig.deprecatedWorkerDispatcher


### PR DESCRIPTION
Using SharedFlow can lead to ANRs when the consumer is slow and the producer emits on the main thread.
Replacing it reduces the likelihood of ANRs and improves traceability when they do occur.
This will be a seamless change outside the Interactor.
